### PR TITLE
Converts bytes to str before calling json.loads()

### DIFF
--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -27,6 +27,8 @@ class StreamConn(object):
             }
         }))
         r = await ws.recv()
+        if(type(r) is bytes): 
+            r = r.decode('utf-8')
         msg = json.loads(r)
         # TODO: check unauthorized
         self._ws = ws


### PR DESCRIPTION
It fixes the following error while calling json.loads() in some Python versions including 3.5.6:
TypeError: the JSON object must be str, not 'bytes'