### PR TITLE
localizing the dates in Eastern time

### DIFF
--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -66,8 +66,8 @@ class Aggs(list):
                 # astype is necessary to deal with empty result
                 df.index = pd.to_datetime(
                     df.index.astype('int64') * 1000000,
-                    utc=True,
-                ).tz_convert(NY)
+                    utc=False,
+                ).tz_localize(NY)
             else:
                 df.set_index('day', inplace=True)
                 df.index = pd.to_datetime(


### PR DESCRIPTION
Before this commit, I was getting a dataframe with wrong timestamps.
For example, when running this code:

```
today = pd.Timestamp.now().tz_localize('US/Eastern').replace(minute=0, hour=0)
aapl = api.polygon.historic_agg('minute', 'AAPL', _from=today, limit=1000).df
```

When seeing the df like `print(aapl)` I was getting a wrong timestamp: `2019-05-03 04:01:00-04:00 `, 
This fix commit fixes the dates to the expected `2019-05-03 08:01:00-04:00`