### PR TITLE
Fix error when aggregate result is empty

### DIFF
--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -81,8 +81,9 @@ class Aggs(list):
 
 class Aggsv2(list):
     def __init__(self, raw):
+        results = raw['results'] if raw.get('results') else []
         super().__init__(
-            Agg(tick) for tick in raw['results']
+            [Agg(tick) for tick in results]
         )
         self._raw = raw
 

--- a/tests/test_polygon/test_rest.py
+++ b/tests/test_polygon/test_rest.py
@@ -10,7 +10,9 @@ def reqmock():
 
 
 def endpoint(path, params='', api_version='v1'):
-    return 'https://api.polygon.io/{}{}?{}&apiKey=key-id'.format(api_version, path, params)
+    return 'https://api.polygon.io/{}{}?{}&apiKey=key-id'.format(
+      api_version, path, params
+    )
 
 
 def test_polygon(reqmock):
@@ -218,8 +220,10 @@ def test_polygon(reqmock):
 
 # Historic Aggregates V2
     reqmock.get(
-        endpoint('/aggs/ticker/AAPL/range/1/day/2018-2-2/2018-2-5',
-          params='unadjusted=False', api_version='v2'),
+        endpoint(
+          '/aggs/ticker/AAPL/range/1/day/2018-2-2/2018-2-5',
+          params='unadjusted=False', api_version='v2'
+        ),
         text='''
 {
   "ticker": "AAPL",
@@ -239,9 +243,11 @@ def test_polygon(reqmock):
   ]
 }''')
 
-    aggs = cli.historic_agg_v2('AAPL', 1, 'day',
-                            _from='2018-2-2',
-                            to='2018-2-5')
+    aggs = cli.historic_agg_v2(
+      'AAPL', 1, 'day',
+      _from='2018-2-2',
+      to='2018-2-5'
+    )
     assert aggs[0].o == 173.15
     assert len(aggs) == 1
     assert aggs.df.iloc[0].h == 173.21

--- a/tests/test_polygon/test_rest.py
+++ b/tests/test_polygon/test_rest.py
@@ -9,8 +9,8 @@ def reqmock():
         yield m
 
 
-def endpoint(path, params=''):
-    return 'https://api.polygon.io/v1{}?apiKey=key-id&{}'.format(path, params)
+def endpoint(path, params='', api_version='v1'):
+    return 'https://api.polygon.io/{}{}?{}&apiKey=key-id'.format(api_version, path, params)
 
 
 def test_polygon(reqmock):
@@ -215,6 +215,38 @@ def test_polygon(reqmock):
     assert aggs[0].day.day == 2
     assert len(aggs) == 1
     assert aggs.df.iloc[0].high == 173.21
+
+# Historic Aggregates V2
+    reqmock.get(
+        endpoint('/aggs/ticker/AAPL/range/1/day/2018-2-2/2018-2-5',
+          params='unadjusted=False', api_version='v2'),
+        text='''
+{
+  "ticker": "AAPL",
+  "status": "OK",
+  "adjusted": true,
+  "queryCount": 55,
+  "resultsCount": 2,
+  "results": [
+    {
+      "o": 173.15,
+      "c": 173.2,
+      "l": 173.15,
+      "h": 173.21,
+      "v": 1800,
+      "t": 1517529605000
+    }
+  ]
+}''')
+
+    aggs = cli.historic_agg_v2('AAPL', 1, 'day',
+                            _from='2018-2-2',
+                            to='2018-2-5')
+    assert aggs[0].o == 173.15
+    assert len(aggs) == 1
+    assert aggs.df.iloc[0].h == 173.21
+    with pytest.raises(AttributeError):
+        aggs[0].foo
 
     # Last Trade
     reqmock.get(


### PR DESCRIPTION
A user discovered that when getting recent aggregate data for companies that have not been traded yet, the result list can be empty and an error would be thrown. This corrects the error and instead returns an empty list.