### PR TITLE
Add reconnection handling into Polygon WS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'requests',
         'urllib3<1.25',
         'websocket-client',
-        'websockets',
+        'websockets>=8.0',
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
This PR is an attempt to add some re-connection logic into the polygon websockets interface.  Currently it will use the same ENV variables as the REST api for retry count and delay if connections keep failing.

This PR also introduces two synthetic events that can be seen by the caller in the status event handler, an example re-connection trace looks like:
```
Entity({'ev': 'status', 'message': 'subscribed to: A.*', 'status': 'success'})
Entity({   'ev': 'status',
    'message': 'Polygon Disconnected Unexpectedly',
    'status': 'disconnected'})
Entity({'ev': 'status', 'message': 'Connecting to Polygon', 'status': 'connecting'})
Entity({'ev': 'status', 'message': 'Connecting to Polygon', 'status': 'connecting'})
Entity({'ev': 'status', 'message': 'Connected Successfully', 'status': 'connected'})
Entity({'ev': 'status', 'message': 'authenticated', 'status': 'success'})
```

Bumps websocket dependency to 8.0 which was just released that includes improvements in the exceptions it generates.

Replaces #73, Closes #61, #64