### PR TITLE
Further improvments to feature/polygon_reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,17 @@ conn = StreamConn()
 async def on_account_updates(conn, channel, account):
     print('account', account)
 
+@conn.on(r'^status$')
+def on_status(conn, channel, data):
+    print('polygon status update', data)
 
 @conn.on(r'^AM$')
-def on_bars(conn, channel, bar):
+def on_minute_bars(conn, channel, bar):
     print('bars', bar)
 
+@conn.on(r'^A$')
+def on_second_bars(conn, channel, bar):
+    print('bars', bar)
 
 # blocks forever
 conn.run(['account_updates', 'AM.*'])
@@ -203,6 +209,9 @@ unless an exception is raised.
 
 ### StreamConn.subscribe(channels)
 Request "listen" to the server.  `channels` must be a list of string channel names.
+
+### StreamConn.unsubscribe(channels)
+Request to stop "listening" to the server.  `channels` must be a list of string channel names.
 
 ### StreamConn.run(channels)
 Goes into an infinite loop and awaits for messages from the server.  You should

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -98,6 +98,28 @@ class StreamConn(object):
             await self._ensure_polygon()
             await self.polygon.subscribe(polygon_channels)
 
+    async def unsubscribe(self, channels):
+        '''Handle un-subscribing from channels.
+        '''
+        if not self._ws:
+            return
+
+        ws_channels = []
+        polygon_channels = []
+        for c in channels:
+            if c.startswith(('Q.', 'T.', 'A.', 'AM.',)):
+                polygon_channels.append(c)
+            else:
+                ws_channels.append(c)
+
+        if len(ws_channels) > 0:
+            # Currently our streams don't support unsubscribe
+            # not as useful with our feeds
+            pass
+
+        if len(polygon_channels) > 0:
+            await self.polygon.unsubscribe(polygon_channels)
+
     def run(self, initial_channels=[]):
         '''Run forever and block until exception is rasised.
         initial_channels is the channels to start with.


### PR DESCRIPTION
There are some significant changes in this PR.  Notably, the _recv() async generator was created to refactor all the places where we were de-serializing the websocket messages.  

The subscribe and new unsubscribe functions keep track of the _streams we're listing to so that it can use that list to re-subscribe in the future if we need to reconnect.

The re-connection logic has been improved.  If the connection dies unexpectedly, we will retry the connection.  If Polygon sends us a `disconnect` on the stream, we will raise that as an Exception and not retry, typically this means another WSS reader has started up, no sense in having two clients fight back and forth.