### PR TITLE
Polygon streaming _handlers reference fix

### DIFF
--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -68,8 +68,8 @@ class StreamConn(object):
         if 'staging' in self._base_url:
             key_id += '-staging'
         self.polygon = polygon.StreamConn(key_id)
-        self.polygon._handlers = self._handlers
-        self.polygon._handler_symbols = self._handler_symbols
+        self.polygon._handlers = self._handlers.copy()
+        self.polygon._handler_symbols = self._handler_symbols.copy()
         await self.polygon.connect()
 
     async def _ensure_ws(self):


### PR DESCRIPTION
Fixed both StreamConn._handlers and StreamConn.polygon._handlers referencing the same object and thus causing KeyErrors on StreamConn.deregister() by shallow cloning the _handlers dictionary in StreamConn._ensure_polygon().