### PR TITLE
Add automatic reconnection for Alpaca stream

### DIFF
--- a/alpaca_trade_api/polygon/streamconn.py
+++ b/alpaca_trade_api/polygon/streamconn.py
@@ -121,13 +121,12 @@ class StreamConn(object):
                 await self.connect()
                 if self._streams:
                     await self.subscribe(self._streams)
-
                 break
-            except (ConnectionRefusedError, ConnectionError) as e:
+            except Exception as e:
                 await self._dispatch({'ev': 'status',
                                       'status': 'connect failed',
                                       'message':
-                                      f'Connection Failed ({e})'})
+                                      f'Polygon Connection Failed ({e})'})
                 self._ws = None
                 self._retries += 1
                 time.sleep(self._retry_wait * self._retry)

--- a/alpaca_trade_api/polygon/streamconn.py
+++ b/alpaca_trade_api/polygon/streamconn.py
@@ -88,10 +88,7 @@ class StreamConn(object):
                 msg = json.loads(r)
                 for update in msg:
                     yield update
-        except websockets.exceptions.ConnectionClosed:
-            # Ignore, occurs on self.close() such as after KeyboardInterrupt
-            pass
-        except websockets.exceptions.ConnectionClosedError as e:
+        except Exception as e:
             await self._dispatch({'ev': 'status',
                                   'status': 'disconnected',
                                   'message':

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -67,10 +67,7 @@ class StreamConn(object):
                 stream = msg.get('stream')
                 if stream is not None:
                     await self._dispatch(stream, msg)
-        except websockets.exceptions.ConnectionClosed:
-            # Ignore, occurs on self.close() such as after KeyboardInterrupt
-            pass
-        except websockets.exceptions.ConnectionClosedError:
+        except:
             await self.close()
             asyncio.ensure_future(self._ensure_ws())
 

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -26,7 +26,7 @@ class StreamConn(object):
         self.polygon = None
         try:
             self.loop = asyncio.get_event_loop()
-        except:
+        except Exception:
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
 
@@ -96,7 +96,7 @@ class StreamConn(object):
                 if self._streams:
                     await self.subscribe(self._streams)
                 break
-            except Exception as e:
+            except Exception:
                 self._ws = None
                 self._retries += 1
                 time.sleep(self._retry_wait * self._retry)

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import os
 import re
-import time
 import websockets
 from .common import get_base_url, get_credentials
 from .entity import Account, Entity
@@ -99,7 +98,7 @@ class StreamConn(object):
             except Exception:
                 self._ws = None
                 self._retries += 1
-                time.sleep(self._retry_wait * self._retry)
+                await asyncio.sleep(self._retry_wait * self._retry)
         else:
             raise ConnectionError("Max Retries Exceeded")
 

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -67,7 +67,7 @@ class StreamConn(object):
                 stream = msg.get('stream')
                 if stream is not None:
                     await self._dispatch(stream, msg)
-        except:
+        except Exception:
             await self.close()
             asyncio.ensure_future(self._ensure_ws())
 

--- a/tests/test_stream2.py
+++ b/tests/test_stream2.py
@@ -77,10 +77,6 @@ def test_stream(websockets):
     async def on_raise(conn, stream, msg):
         raise TestException()
 
-    with pytest.raises(TestException):
-        _run(conn._consume_msg())
-    assert ws.close.mock.called
-
     # _ensure_polygon
     conn = StreamConn('key-id', 'secret-key')
     with mock.patch('alpaca_trade_api.stream2.polygon') as polygon:
@@ -94,7 +90,6 @@ def test_stream(websockets):
     conn._connect = AsyncMock()
     _run(conn._ensure_ws())
     assert conn._connect.mock.called
-    assert conn._ws is not None
 
     # subscribe
     conn = StreamConn('key-id', 'secret-key')
@@ -116,8 +111,8 @@ def test_stream(websockets):
     conn.polygon = mock.Mock()
     conn.polygon.close = AsyncMock()
     _run(conn.close())
-    assert conn._ws.close.mock.called
-    assert conn.polygon.close.mock.called
+    assert conn._ws is None
+    assert conn.polygon is None
 
     # _cast
     conn = StreamConn('key-id', 'secret-key')


### PR DESCRIPTION
Though the Alpaca API itself rarely closes websocket connections, local network conditions have caused some users to report abnormal connection closures. This should address some of the issues people have been seeing as a result.