### PR TITLE
Incorrect bar timeframe

### DIFF
--- a/examples/long-short.py
+++ b/examples/long-short.py
@@ -309,7 +309,7 @@ class LongShort:
   def getPercentChanges(self):
     length = 10
     for i, stock in enumerate(self.allStocks):
-      bars = self.alpaca.get_barset(stock[0], 'minute', length)
+      bars = self.alpaca.get_barset(stock[0], 'day', length)
       self.allStocks[i][1] = (bars[stock[0]][len(bars[stock[0]]) - 1].c - bars[stock[0]][0].o) / bars[stock[0]][0].o
 
   # Mechanism used to rank the stocks, the basis of the Long-Short Equity Strategy.


### PR DESCRIPTION
Comment says 10 days, but it is actually getting 10 minutes

Also the bar endpoint documentation is very confusing.
https://docs.alpaca.markets/api-documentation/api-v2/market-data/bars/
It doesn't specify what is the behavior w/o start, end, after, until.

I also try with a query with start=2019-10-25T09:30:00 end=2019-10-25T16:00:00, but the first bar is for October 25, 2019 1:34:00 PM
The last is bar is starting from October 25, 2019 3:59:00 PM
There are 100 bars in total. However I am not sure how these 100 minute bar is distributed around an about 2 and a half hour time span.
