### PR TITLE
First Impression Solved : Add Base Url URL at REST Module

### DIFF
--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -58,7 +58,7 @@ class REST(object):
         self,
         key_id=None,
         secret_key=None,
-        base_url=None,
+        base_url='https://paper-api.alpaca.markets',
         api_version=None,
         oauth=None
     ):


### PR DESCRIPTION
![JupyterLab (2)](https://user-images.githubusercontent.com/32424891/70672245-40b52f00-1c87-11ea-8534-2d4293acfede.png)

my first impression about package it was : why that error at just start after that i checked Issue's, i fount that i must add `https://paper-api.alpaca.markets` as Third Parameter Like Next Code 
While in The Docs you didn't Explain this point at that quick start

That Code Case Error :-1: 
```
import alpaca_trade_api as tradeapi

api = tradeapi.REST('<key_id>', '<secret_key>', api_version='v2') # or use ENV Vars shown below
account = api.get_account()
api.list_positions()
```

That Code Works Fine :+1: 
```
import alpaca_trade_api as tradeapi

api = tradeapi.REST('<key_id>', '<secret_key>','https://paper-api.alpaca.markets', api_version='v2') # or use ENV Vars shown below
account = api.get_account()
api.list_positions()
```

So i Added `'https://paper-api.alpaca.markets'` as Default Parameter if we Pass None .
