### PR TITLE
Add Polygon end-pt: Daily Open/Close

### DIFF
--- a/alpaca_trade_api/polygon/rest.py
+++ b/alpaca_trade_api/polygon/rest.py
@@ -134,6 +134,13 @@ class REST(object):
         raw = self.get(path, params, version='v2')
         return Aggsv2(raw)
 
+
+    def daily_open_close(self, symbol, date):
+        path = '/open-close/{}/{}'.format(symbol, date)
+        raw = self.get(path)
+        return raw
+
+
     def grouped_daily(self, date, unadjusted=False):
         path = '/aggs/grouped/locale/US/market/STOCKS/{}'.format(date)
         params = {}


### PR DESCRIPTION
This PR adds support for the following Polygon endpoint:
[https://polygon.io/docs/#!/Stocks--Equities/get_v1_open_close_symbol_date](https://polygon.io/docs/#!/Stocks--Equities/get_v1_open_close_symbol_date)

Current (Polygon) methods supported in the API return daily close data from 1 day prior, but not from the same day as requested.