### PR TITLE
bugfix specify seconds as timestamp unit

### DIFF
--- a/alpaca_trade_api/entity.py
+++ b/alpaca_trade_api/entity.py
@@ -176,7 +176,7 @@ class PortfolioHistory(Entity):
                 ).tz_convert(NY)
             else:
                 df.index = pd.to_datetime(
-                    df.index, utc=True
+                    df.index, utc=True, unit='s'
                 )
             self._df = df
         return self._df


### PR DESCRIPTION
API returns timestamp in seconds, pandas to_datetime() has a default of ns https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.to_datetime.html