### PR TITLE
Revert "bugfix specify seconds as timestamp unit"

### DIFF
--- a/alpaca_trade_api/entity.py
+++ b/alpaca_trade_api/entity.py
@@ -176,7 +176,7 @@ class PortfolioHistory(Entity):
                 ).tz_convert(NY)
             else:
                 df.index = pd.to_datetime(
-                    df.index, utc=True, unit='s'
+                    df.index, utc=True
                 )
             self._df = df
         return self._df


### PR DESCRIPTION
Reverts alpacahq/alpaca-trade-api-python#164

Change was unnecessary as the dataframe index is already adjusted.