### PR TITLE
Entity float attribute should be float

### DIFF
--- a/alpaca_trade_api/entity.py
+++ b/alpaca_trade_api/entity.py
@@ -25,6 +25,11 @@ class Entity(object):
                     ISO8601YMD.match(val)):
                 return pd.Timestamp(val)
             else:
+                if isinstance(val, str):
+                    try:
+                        val = float(val)
+                    except ValueError:
+                        pass
                 return val
         return super().__getattribute__(key)
 


### PR DESCRIPTION
rest api returns data as string.
 we already transform datetime objects to Timestamp. 
let's also do that for floats