### PR TITLE
Fix Runtine error when trying to get event loop

### DIFF
--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -25,7 +25,7 @@ class StreamConn(object):
         self.polygon = None
         try:
             self.loop = asyncio.get_event_loop()
-        except websockets.WebSocketException as wse:
+        except (websockets.WebSocketException, RuntimeError) as wse:
             logging.warn(wse)
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)


### PR DESCRIPTION
asyncio.get_event_loop() throws Runtime error because event loop doesn't exist in thread
we need to add that to the available exceptions that we create a new event loop when we get them