### PR TITLE
Fixing error handling in stream2.py

### DIFF
--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -23,12 +23,13 @@ class StreamConn(object):
         self._retry_wait = int(os.environ.get('APCA_RETRY_WAIT', 3))
         self._retries = 0
         self.polygon = None
+        
         try:
             self.loop = asyncio.get_event_loop()
-        except websockets.WebSocketException as wse:
-            logging.warn(wse)
+        except:
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
+
 
     async def _connect(self):
         ws = await websockets.connect(self._endpoint)


### PR DESCRIPTION
The exception handling in stream2.py doesn't seem to catch the right exception:  

2020-04-10T15:24:39.787817+00:00 app[worker.1]: Exception in thread Thread-7:
2020-04-10T15:24:39.787818+00:00 app[worker.1]: Traceback (most recent call last):
2020-04-10T15:24:39.787819+00:00 app[worker.1]: File "/app/.heroku/python/lib/python3.6/threading.py", line 916, in _bootstrap_inner
2020-04-10T15:24:39.787819+00:00 app[worker.1]: self.run()
2020-04-10T15:24:39.787820+00:00 app[worker.1]: File "/app/.heroku/python/lib/python3.6/threading.py", line 864, in run
2020-04-10T15:24:39.787821+00:00 app[worker.1]: self._target(*self._args, **self._kwargs)
2020-04-10T15:24:39.787821+00:00 app[worker.1]: File "/app/.heroku/python/lib/python3.6/site-packages/alpaca_backtrader_api/alpacastore.py", line 449, in _t_streaming_prices
2020-04-10T15:24:39.787821+00:00 app[worker.1]: base_url=self.p.base_url)
2020-04-10T15:24:39.787822+00:00 app[worker.1]: File "/app/.heroku/python/lib/python3.6/site-packages/alpaca_backtrader_api/alpacastore.py", line 94, in __init__
2020-04-10T15:24:39.787822+00:00 app[worker.1]: self.conn = tradeapi.StreamConn(api_key, api_secret, base_url)
2020-04-10T15:24:39.787823+00:00 app[worker.1]: File "/app/.heroku/python/lib/python3.6/site-packages/alpaca_trade_api/stream2.py", line 27, in __init__
2020-04-10T15:24:39.787823+00:00 app[worker.1]: self.loop = asyncio.get_event_loop()
2020-04-10T15:24:39.787823+00:00 app[worker.1]: File "/app/.heroku/python/lib/python3.6/asyncio/events.py", line 694, in get_event_loop
2020-04-10T15:24:39.787824+00:00 app[worker.1]: return get_event_loop_policy().get_event_loop()
2020-04-10T15:24:39.787824+00:00 app[worker.1]: File "/app/.heroku/python/lib/python3.6/asyncio/events.py", line 602, in get_event_loop
2020-04-10T15:24:39.787825+00:00 app[worker.1]: % threading.current_thread().name)
2020-04-10T15:24:39.787825+00:00 app[worker.1]: RuntimeError: There is no current event loop in thread 'Thread-7'.


So I changed it to catch any exception which is probably a bit heavy handed but that is the exception type that is thrown: https://github.com/python/cpython/blob/master/Lib/asyncio/events.py#L643
