### PR TITLE
create new event_loop for threads

### DIFF
--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -197,8 +197,8 @@ class StreamConn(object):
 
         try:
             self.loop = asyncio.get_event_loop()
-        except websockets.WebSocketException as wse:
-            logging.warn(wse)
+        except RuntimeError as e:
+            logging.warn(e)
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
 


### PR DESCRIPTION
Backtrader library run strategies in threads. Those don't have an event loop, causing a runtime exception.
See: https://forum.alpaca.markets/t/alpaca-backtrader-api-gives-threading-error-on-running-sample-code/528