### PR TITLE
Add ability to get paginated symbol list from polygon

### DIFF
--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -315,6 +315,9 @@ class NewsList(EntityList):
 class Ticker(Entity):
     pass
 
+class Symbol(Entity):
+    pass
+
 
 class DailyOpenClose(Entity):
     pass

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -315,6 +315,7 @@ class NewsList(EntityList):
 class Ticker(Entity):
     pass
 
+
 class Symbol(Entity):
     pass
 

--- a/alpaca_trade_api/polygon/rest.py
+++ b/alpaca_trade_api/polygon/rest.py
@@ -309,7 +309,7 @@ class REST(object):
         :param per_page: number of results per page
         :return:
         """
-        path = f'/reference/tickers'
+        path = '/reference/tickers'
         return [Symbol(s) for s in self.get(path,
                                             version='v2',
                                             params={

--- a/alpaca_trade_api/polygon/rest.py
+++ b/alpaca_trade_api/polygon/rest.py
@@ -8,7 +8,7 @@ from .entity import (
     Quote, Quotes, QuotesV2,
     Exchange, SymbolTypeMap, ConditionMap,
     Company, Dividends, Splits, Earnings, Financials, NewsList, Ticker,
-    DailyOpenClose
+    DailyOpenClose, Symbol
 )
 from alpaca_trade_api.common import get_polygon_credentials, URL, DATE
 from deprecated import deprecated
@@ -16,6 +16,7 @@ from deprecated import deprecated
 
 Exchanges = List[Exchange]
 Tickers = List[Ticker]
+Symbols = List[Symbol]
 
 
 def _is_list_like(o) -> bool:
@@ -298,6 +299,24 @@ class REST(object):
             Ticker(ticker) for ticker in
             self.get(path, version='v2')['tickers']
         ]
+
+    def symbol_list_paginated(self, page: int, per_page: int) -> Symbols:
+        """
+        this api /v2/reference/tickers returns paginated data.
+        the user could specify the page to get data for
+        :param page: page number
+        :param per_page: number of results per page
+        :return:
+        """
+        path = f'/reference/tickers'
+        return [Symbol(s) for s in self.get(path,
+                                            version='v2',
+                                            params={
+                                                "page": page,
+                                                "active": "true",
+                                                "perpage": per_page,
+                                                "market": "STOCKS"
+                                            })['tickers']]
 
     def snapshot(self, symbol: str) -> Ticker:
         path = '/snapshot/locale/us/markets/stocks/tickers/{}'.format(symbol)

--- a/alpaca_trade_api/polygon/rest.py
+++ b/alpaca_trade_api/polygon/rest.py
@@ -300,7 +300,8 @@ class REST(object):
             self.get(path, version='v2')['tickers']
         ]
 
-    def symbol_list_paginated(self, page: int, per_page: int) -> Symbols:
+    def symbol_list_paginated(self, page: int = 1,
+                              per_page: int = 50) -> Symbols:
         """
         this api /v2/reference/tickers returns paginated data.
         the user could specify the page to get data for

--- a/tests/test_polygon/test_rest.py
+++ b/tests/test_polygon/test_rest.py
@@ -344,7 +344,7 @@ def test_polygon(reqmock):
     reqmock.get(
         endpoint('/reference/tickers', api_version='v2'),
         text='''
-[
+{"page": 1, "perPage": 30, "count": 32657, "status": "OK", "tickers": [
   {
     "ticker": "AAPL",
     "name": "Apple Inc.",
@@ -383,7 +383,7 @@ def test_polygon(reqmock):
     "updated": "2019-01-15T05:21:28.437Z",
     "url": "https://api.polygon.io/v2/reference/tickers/GOOG"
   }
-]''')
+]}''')
     cli.symbol_list_paginated(1, 2)
     # nothing to assert in the mock data. jsut checking params are parsed
     # correctly

--- a/tests/test_polygon/test_rest.py
+++ b/tests/test_polygon/test_rest.py
@@ -342,7 +342,7 @@ def test_polygon(reqmock):
 
     # paginated symbol list
     reqmock.get(
-        endpoint('/meta/symbols/AAPL/news'),
+        endpoint('/meta/symbols/AAPL/news', api_version='v2'),
         text='''
 [
   {
@@ -383,8 +383,7 @@ def test_polygon(reqmock):
     "updated": "2019-01-15T05:21:28.437Z",
     "url": "https://api.polygon.io/v2/reference/tickers/GOOG"
   }
-]''', api_version='v2'
-    )
+]''')
     cli.symbol_list_paginated(1, 2)
     # nothing to assert in the mock data. jsut checking params are parsed
     # correctly

--- a/tests/test_polygon/test_rest.py
+++ b/tests/test_polygon/test_rest.py
@@ -342,7 +342,7 @@ def test_polygon(reqmock):
 
     # paginated symbol list
     reqmock.get(
-        endpoint('/meta/symbols/AAPL/news', api_version='v2'),
+        endpoint('/reference/tickers', api_version='v2'),
         text='''
 [
   {

--- a/tests/test_polygon/test_rest.py
+++ b/tests/test_polygon/test_rest.py
@@ -339,3 +339,52 @@ def test_polygon(reqmock):
 
     with pytest.raises(ValueError):
         cli.company(['AAPL'] * 51)
+
+    # paginated symbol list
+    reqmock.get(
+        endpoint('/meta/symbols/AAPL/news'),
+        text='''
+[
+  {
+    "ticker": "AAPL",
+    "name": "Apple Inc.",
+    "market": "STOCKS",
+    "locale": "US",
+    "currency": "USD",
+    "active": true,
+    "primaryExch": "NGS",
+    "type": "cs",
+    "codes": {
+      "cik": "0000320193",
+      "figiuid": "EQ0010169500001000",
+      "scfigi": "BBG001S5N8V8",
+      "cfigi": "BBG000B9XRY4",
+      "figi": "BBG000B9Y5X2"
+    },
+    "updated": "2019-01-15T05:21:28.437Z",
+    "url": "https://api.polygon.io/v2/reference/tickers/AAPL"
+  },
+  {
+    "ticker": "GOOG",
+    "name": "Google Inc.",
+    "market": "STOCKS",
+    "locale": "US",
+    "currency": "USD",
+    "active": true,
+    "primaryExch": "NGS",
+    "type": "cs",
+    "codes": {
+      "cik": "0000320193",
+      "figiuid": "EQ0010169500001000",
+      "scfigi": "BBG001S5N8V8",
+      "cfigi": "BBG000B9XRY4",
+      "figi": "BBG000B9Y5X2"
+    },
+    "updated": "2019-01-15T05:21:28.437Z",
+    "url": "https://api.polygon.io/v2/reference/tickers/GOOG"
+  }
+]''', api_version='v2'
+    )
+    cli.symbol_list_paginated(1, 2)
+    # nothing to assert in the mock data. jsut checking params are parsed
+    # correctly


### PR DESCRIPTION
handles this issue: 
https://github.com/alpacahq/alpaca-trade-api-python/issues/193

polygon reference:
https://polygon.io/docs/#get_v2_reference_tickers_anchor