### PR TITLE
validate stop/limit prices before passed to the server

### DIFF
--- a/alpaca_trade_api/common.py
+++ b/alpaca_trade_api/common.py
@@ -41,6 +41,26 @@ class DATE(str):
         return str.__new__(cls, value)
 
 
+class FLOAT(str):
+    """
+    api allows passing floats or float as strings.
+    let's make sure that param passed is one of the two, so we don't pass
+    invalid strings all the way to the servers.
+    """
+    def __new__(cls, value):
+        if not value:
+            raise ValueError('Unexpected empty string')
+        if isinstance(value, float) or isinstance(value, int):
+            pass  # we're good
+        elif isinstance(value, str):
+            value = value.strip()  # make sure no spaces
+            if isinstance(float(value), float):
+                pass  # we're good
+        else:
+            raise ValueError(f'Unexpected float format "{value}"')
+        return value
+
+
 def get_base_url() -> URL:
     return URL(os.environ.get(
         'APCA_API_BASE_URL', 'https://api.alpaca.markets').rstrip('/'))

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -8,7 +8,7 @@ from .common import (
     get_base_url,
     get_data_url,
     get_credentials,
-    get_api_version, URL,
+    get_api_version, URL, FLOAT,
 )
 from .entity import (
     Account, AccountConfigurations, AccountActivity,
@@ -282,9 +282,9 @@ class REST(object):
             'time_in_force': time_in_force,
         }
         if limit_price is not None:
-            params['limit_price'] = limit_price
+            params['limit_price'] = FLOAT(limit_price)
         if stop_price is not None:
-            params['stop_price'] = stop_price
+            params['stop_price'] = FLOAT(stop_price)
         if client_order_id is not None:
             params['client_order_id'] = client_order_id
         if extended_hours is not None:
@@ -332,9 +332,9 @@ class REST(object):
         if qty is not None:
             params['qty'] = qty
         if limit_price is not None:
-            params['limit_price'] = limit_price
+            params['limit_price'] = FLOAT(limit_price)
         if stop_price is not None:
-            params['stop_price'] = stop_price
+            params['stop_price'] = FLOAT(stop_price)
         if time_in_force is not None:
             params['time_in_force'] = time_in_force
         if client_order_id is not None:

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -149,6 +149,49 @@ def test_orders(reqmock):
     )
     assert order.qty == "15"
     assert order.created_at.hour == 19
+    # now let's test some different acceptable "float" formats
+    api.submit_order(
+        symbol='904837e3-3b76-47ec-b432-046db621571b',
+        qty=15,
+        side='buy',
+        type='market',
+        time_in_force='day',
+        limit_price='107.00',  # str float
+        stop_price=106.00,  # float
+        client_order_id='904837e3-3b76-47ec-b432-046db621571b',
+    )
+    api.submit_order(
+        symbol='904837e3-3b76-47ec-b432-046db621571b',
+        qty=15,
+        side='buy',
+        type='market',
+        time_in_force='day',
+        limit_price='107.00',  # str float
+        stop_price=106,  # int
+        client_order_id='904837e3-3b76-47ec-b432-046db621571b',
+    )
+    with pytest.raises(ValueError):
+        api.submit_order(
+            symbol='904837e3-3b76-47ec-b432-046db621571b',
+            qty=15,
+            side='buy',
+            type='market',
+            time_in_force='day',
+            limit_price='1',
+            stop_price="a",
+            client_order_id='904837e3-3b76-47ec-b432-046db621571b',
+        )
+    with pytest.raises(ValueError):
+        api.submit_order(
+            symbol='904837e3-3b76-47ec-b432-046db621571b',
+            qty=15,
+            side='buy',
+            type='market',
+            time_in_force='day',
+            limit_price='a',
+            stop_price=106.00,
+            client_order_id='904837e3-3b76-47ec-b432-046db621571b',
+        )
 
     # Get an order by client order id
     client_order_id = 'client-order-id'


### PR DESCRIPTION
we could pass stop/limit prices as floats or as string float to the api
when you add this flexibility, you may cause errors by wrong usage
e.g we could pass "a" and the request will go to the server but the result will be bad
by adding this, we will raise an exception before the request leaves the user's code
allowing to find errors earlier at runtime