### PR TITLE
Require pandas<0.23

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-pandas
+pandas<0.23
 requests
 urllib3<1.25
 websocket-client


### PR DESCRIPTION
pylivetrader is using zipline 1.3.0
that package has that constraint.
we add it here too