### PR TITLE
Make sure that historic_aggs returns the 'to' data for daily bars

### DIFF
--- a/tests/test_polygon/test_rest.py
+++ b/tests/test_polygon/test_rest.py
@@ -78,14 +78,14 @@ def test_polygon(reqmock):
 
     reqmock.get(
         endpoint(
-            '/aggs/ticker/AAPL/range/1/day/2018-02-02/2018-02-05',
+            '/aggs/ticker/AAPL/range/1/day/2018-02-02/2018-02-06',
             params='unadjusted=False', api_version='v2'
         ),
         text=aggs_response)
 
     reqmock.get(
         endpoint(
-            '/aggs/ticker/AAPL/range/1/day/1546300800000/2018-02-05',
+            '/aggs/ticker/AAPL/range/1/day/1546300800000/2018-02-06',
             params='unadjusted=False', api_version='v2'
         ),
         text=aggs_response)


### PR DESCRIPTION
the polygon api does not include the end date for daily bars, or this:
```
    historic_agg_v2("SPY", 1, "day", _from="2020-07-22", to="2020-07-24").df
    results in this:
    timestamp
    2020-07-22 00:00:00-04:00  324.62  327.20  ...  57917101.0  325.8703
    2020-07-23 00:00:00-04:00  326.47  327.23  ...  75841843.0  324.3429
```
    the 24th data is missing
    for minute bars, it does include the end date

    so basically this method will add 1 day (if 'to' is not today, we don't
    have today's data until tomorrow) to the 'to' field