### PR TITLE
Fix TypeError: 'NoneType' object is not iterable when getting empty response from polygon Aggs api

### DIFF
--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -93,7 +93,14 @@ class Aggsv2(list):
         ])
 
     def _raw_results(self):
-        return self._raw.get('results', [])
+        results = self._raw.get('results')
+        if not results:
+            # this is not very pythonic but it's written like this because
+            # the raw response for empty aggs was None, and this:
+            # self._raw.get('results', []) returns None, not [] which breaks
+            # when we try to iterate it.
+            return []
+        return results
 
     def rename_keys(self):
         colmap = {


### PR DESCRIPTION
When we get an empty response from polygon's aggs api it's returned as `None`
and what we do is `self._raw.get('results', [])` which returns `None`
we then try to iterate it, and get: 
`TypeError: 'NoneType' object is not iterable`

we fix it like this