### PR TITLE
Increase ws consume() exceptions verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,19 @@ same `channel_pat` will overwrite the old handler.
 Deregisters the event handler function that was previously registered via `on` or
 `register` method.
 
+#### Debugging
+Websocket exceptions may occur during execution.
+It will usually happen during the `consume()` method, which basically is the 
+websocket steady-state.<br>
+exceptions during the consume method may occur due to:
+- server disconnections
+- error while handling the response data
+
+We handle the first issue by reconnecting the websocket every time there's a disconnection.
+The second issue, is usually a user's code issue. To help you find it, we added a flag to the 
+StreamConn object called `debug`. It is set to False by default, but you can turn it on to get a more
+verbose logs when this exception happens.
+Turn it on like so `StreamConn(debug=True)`  
 
 ---
 # Polygon API Service

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import re
+import traceback
 from asyncio import CancelledError
 
 import websockets
@@ -183,7 +184,9 @@ class StreamConn(object):
             secret_key: str = None,
             base_url: URL = None,
             data_url: URL = None,
-            data_stream: str = None):
+            data_stream: str = None,
+            debug: bool = False
+    ):
         self._key_id, self._secret_key, _ = get_credentials(key_id, secret_key)
         self._base_url = base_url or get_base_url()
         self._data_url = data_url or get_data_url()
@@ -196,6 +199,7 @@ class StreamConn(object):
         else:
             _data_stream = 'alpacadatav1'
         self._data_stream = _data_stream
+        self._debug = debug
 
         self.trading_ws = _StreamConn(self._key_id,
                                       self._secret_key,
@@ -293,6 +297,8 @@ class StreamConn(object):
             except Exception as e:
                 m = 'consume cancelled' if isinstance(e, CancelledError) else e
                 logging.error(f"error while consuming ws messages: {m}")
+                if self._debug:
+                    traceback.print_exc()
                 loop.run_until_complete(self.close(should_renew))
                 if loop.is_running():
                     loop.close()


### PR DESCRIPTION
When we get ws exceptions in the consume() method, it's usually not
informative enough. but, we may only want to see more information when we debug
by adding the debug flag to the StreamConn object we will add a stacktrace when
consume() related exceptions occur, and give the user more information helping them
to the debug the issue.