### PR TITLE
Allow working with all versions of pandas

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-pandas>1,<2
+pandas  # pyup: ignore 
 requests>2,<3
 urllib3>1.24,<1.26
 websocket-client>=0.56.0,<1


### PR DESCRIPTION
pylivetrader using zipline which requires pandas <=0.22 (circleci tests fail with current restrictions)
we also want to allow up-to-date versions of pandas for other projects/users usage
for that purpose we need to remove the version restrictions.