### PR TITLE
Fix functions for Watchlists API endpoint

### DIFF
--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -548,15 +548,15 @@ class REST(object):
         return Watchlist(resp)
 
     def update_watchlist(self,
-                         watchlist_id,
+                         watchlist_id: str,
                          name: str = None,
-                         symbols=None) -> Watchlist:
+                         symbols = None) -> Watchlist:
         params = {}
         if name is not None:
             params['name'] = name
         if symbols is not None:
             params['symbols'] = symbols
-        resp = self.patch('/watchlists/{}'.format(watchlist_id), data=params)
+        resp = self.put('/watchlists/{}'.format(watchlist_id), data=params)
         return Watchlist(resp)
 
     def delete_watchlist(self, watchlist_id: str) -> None:

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -157,6 +157,9 @@ class REST(object):
 
     def post(self, path, data=None):
         return self._request('POST', path, data)
+    
+    def put(self, path, data=None):
+        return self._request('PUT', path, data)
 
     def patch(self, path, data=None):
         return self._request('PATCH', path, data)

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -530,16 +530,19 @@ class REST(object):
         return [Calendar(o) for o in resp]
 
     def get_watchlists(self) -> Watchlists:
+        """Get the list of watchlists registered under the account"""
         resp = self.get('/watchlists')
         return [Watchlist(o) for o in resp]
 
     def get_watchlist(self, watchlist_id: str) -> Watchlist:
+        """Get a watchlist identified by the ID"""
         resp = self.get('/watchlists/{}'.format((watchlist_id)))
         return Watchlist(resp)
 
     def create_watchlist(self,
                          watchlist_name: str,
                          symbols = None) -> Watchlist:
+        """Create a new watchlist with an optional initial set of assets"""
         params = {
             'name': watchlist_name,
         }
@@ -549,6 +552,7 @@ class REST(object):
         return Watchlist(resp)
 
     def add_to_watchlist(self, watchlist_id: str, symbol: str) -> Watchlist:
+        """Append the asset for a symbol to the end of a watchlist's asset list""" 
         resp = self.post(
             '/watchlists/{}'.format(watchlist_id), data=dict(symbol=symbol)
         )
@@ -558,6 +562,7 @@ class REST(object):
                          watchlist_id: str,
                          name: str = None,
                          symbols = None) -> Watchlist:
+        """Update a watchlist's name and/or asset list"""
         params = {}
         if name is not None:
             params['name'] = name
@@ -567,9 +572,11 @@ class REST(object):
         return Watchlist(resp)
 
     def delete_watchlist(self, watchlist_id: str) -> None:
+        """Delete a watchlist identified by the ID permanently"""
         self.delete('/watchlists/{}'.format(watchlist_id))
 
     def delete_from_watchlist(self, watchlist_id: str, symbol: str) -> None:
+        """Remove an asset from the watchlist's asset list"""
         self.delete('/watchlists/{}/{}'.format(watchlist_id, symbol))
 
     def get_portfolio_history(self,

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -537,9 +537,16 @@ class REST(object):
         resp = self.get('/watchlists/{}'.format((watchlist_id)))
         return Watchlist(resp)
 
-    def add_watchlist(self, watchlist_name: str) -> Watchlists:
-        resp = self.post('/watchlists', data=dict(name=watchlist_name))
-        return [Watchlist(o) for o in resp]
+    def create_watchlist(self,
+                         watchlist_name: str,
+                         symbols = None) -> Watchlist:
+        params = {
+            'name': watchlist_name,
+        }
+        if symbols is not None:
+            params['symbols'] = symbols
+        resp = self.post('/watchlists', data=params)
+        return Watchlist(resp)
 
     def add_to_watchlist(self, watchlist_id: str, symbol: str) -> Watchlist:
         resp = self.post(

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -539,6 +539,14 @@ class REST(object):
         resp = self.get('/watchlists/{}'.format((watchlist_id)))
         return Watchlist(resp)
 
+    def get_watchlist_by_name(self, watchlist_name: str) -> Watchlist:
+        """Get a watchlist identified by its name"""
+        params = {
+            'name': watchlist_name,
+        }
+        resp = self.get('/watchlists:by_name', data=params)
+        return Watchlist(resp)
+
     def create_watchlist(self,
                          watchlist_name: str,
                          symbols = None) -> Watchlist:


### PR DESCRIPTION
## What's in this PR

### Feature:
- **Add PUT HTTPS request method:**
this is used at updating a watchlist (source: [documentation#update-watchlist](https://alpaca.markets/docs/api-documentation/api-v2/watchlist/#update-watchlist))
- **Add get_watchlist_by_name() function:**
this is using the `/v2/watchlists:by_name` endpoint (source: [documentation#endpoints-for-watchlist-name](https://alpaca.markets/docs/api-documentation/api-v2/watchlist/#endpoints-for-watchlist-name))
- **Add optional `symbols` parameter to add_watchlist() function**
you can send an optional initial set of assets at the creation of a watchlist which is not yet supported by the SDK (source: [documentation#create-a-watchlist](https://alpaca.markets/docs/api-documentation/api-v2/watchlist/#create-a-watchlist))

### Bugfix:
- **Fix update_watchlist() function HTTP method**
currently it uses PATCH instead of PUT and this raises an API error
- **Fix add_watchlist() function returning a list**
currently this function instead of returning the freshly created Watchlist object, it returns a list in which each property of the watchlist is converted into a Watchlist entity, like this:
`[Watchlist('id'), Watchlist('account_id'), Watchlist('created_at'), Watchlist('updated_at'), Watchlist('name'), Watchlist('assets')]`
I know that the documentation states that it returns a list, but that's also incorrect, this endpoint returns only one Watchlist entity

### Improvement:
- **Rename add_watchlist() to create_watchlist()**
this reflects the task of the function better in my opinion, plus this name fits better to the documentation
- **Add docstrings and type hints**
added docstrings for the functions based on the documentation and some type hints