### PR TITLE
Fix hanging close after Alpaca WebSocketException, add closing_timeout

### DIFF
--- a/alpaca_trade_api/polygon/streamconn.py
+++ b/alpaca_trade_api/polygon/streamconn.py
@@ -33,7 +33,7 @@ class StreamConn(object):
         await self._dispatch({'ev': 'status',
                               'status': 'connecting',
                               'message': 'Connecting to Polygon'})
-        self._ws = await websockets.connect(self._endpoint)
+        self._ws = await websockets.connect(self._endpoint, close_timeout=1)
         self._stream = self._recv()
 
         msg = await self._next()

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -30,7 +30,7 @@ class _StreamConn(object):
         self._consume_task = None
 
     async def _connect(self):
-        ws = await websockets.connect(self._endpoint)
+        ws = await websockets.connect(self._endpoint, close_timeout=1)
         await ws.send(json.dumps({
             'action': 'authenticate',
             'data': {
@@ -80,7 +80,7 @@ class _StreamConn(object):
                     await self._dispatch(stream, msg)
         except websockets.WebSocketException as wse:
             logging.warn(wse)
-            await self.close()
+            self._ws = None
             asyncio.ensure_future(self._ensure_ws())
 
     async def _ensure_ws(self):
@@ -91,7 +91,7 @@ class _StreamConn(object):
             try:
                 await self._connect()
                 if self._streams:
-                    await self.subscribe(self._streams)
+                    await self.subscribe(list(self._streams))
                 break
             except websockets.WebSocketException as wse:
                 logging.warn(wse)


### PR DESCRIPTION
This fixed an issue I was having where the Alpaca websocket would throw a warning and hang forever. Turns out, it was awaiting on closing the socket even though it was already closed. Setting the socket variable to None and letting it continue to _ensure_ws fixed the issue.

I also added a closing_timeout to the socket connection so it closes the fastest possible.

Finally, I fixed the streams variable being re-passed into subscribe as a Set instead of a List.