### PR TITLE
Add nested query param to get_order

### DIFF
--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -321,9 +321,11 @@ class REST(object):
         resp = self.get('/orders:by_client_order_id', params)
         return Order(resp)
 
-    def get_order(self, order_id: str) -> Order:
+    def get_order(self, order_id: str, nested: bool = None) -> Order:
         """Get an order"""
         params = {}
+        if nested is not None:
+            params['nested'] = nested
         resp = self.get('/orders/{}'.format(order_id), params)
         return Order(resp)
 


### PR DESCRIPTION
Hey.

According to the [docs](https://alpaca.markets/docs/api-documentation/api-v2/orders/) `get_order` can accept query param `nested`.