### PR TITLE
Add support for the alapca-proxy-agent project

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ The Alpaca SDK will check the environment for a number of variables that can be 
 | APCA_RETRY_MAX=3                 | 3                                                                                      | The number of subsequent API calls to retry on timeouts                                                                |
 | APCA_RETRY_WAIT=3                | 3                                                                                      | seconds to wait between each retry attempt                                                                             |
 | APCA_RETRY_CODES=429,504         | 429,504                                                                                | comma-separated HTTP status code for which retry is attempted                                                          |
-| POLYGON_WS_URL                   | wss://socket.polygon.io/stocks                                                  | Endpoint for streaming polygon data.  You likely don't need to change this unless you want to proxy it for example     |
+| POLYGON_WS_URL                   | wss://socket.polygon.io/stocks                                                         | Endpoint for streaming polygon data.  You likely don't need to change this unless you want to proxy it for example     |
 | POLYGON_KEY_ID                   |                                                                                        | Your Polygon key, if it's not the same as your Alpaca API key. Most users will not need to set this to access Polygon. |
+| DATA_PROXY_WS                    |                                                                                        | When using the alpaca-proxy-agent you need to set this environment variable as described here: https://github.com/shlomikushchi/alpaca-proxy-agent |
 
 ## REST
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The Alpaca SDK will check the environment for a number of variables that can be 
 | APCA_RETRY_CODES=429,504         | 429,504                                                                                | comma-separated HTTP status code for which retry is attempted                                                          |
 | POLYGON_WS_URL                   | wss://socket.polygon.io/stocks                                                         | Endpoint for streaming polygon data.  You likely don't need to change this unless you want to proxy it for example     |
 | POLYGON_KEY_ID                   |                                                                                        | Your Polygon key, if it's not the same as your Alpaca API key. Most users will not need to set this to access Polygon. |
-| DATA_PROXY_WS                    |                                                                                        | When using the alpaca-proxy-agent you need to set this environment variable as described here: https://github.com/shlomikushchi/alpaca-proxy-agent |
+| DATA_PROXY_WS                    |                                                                                        | When using the alpaca-proxy-agent you need to set this environment variable as described ![here](https://github.com/shlomikushchi/alpaca-proxy-agent) |
 
 ## REST
 

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -206,6 +206,11 @@ class StreamConn(object):
                                       self._base_url)
 
         if self._data_stream == 'polygon':
+            # DATA_PROXY_WS is used for the alpaca-proxy-agent.
+            # this is how we set the polygon ws to go through the proxy agent
+            endpoint = os.environ.get("DATA_PROXY_WS", '')
+            if endpoint:
+                os.environ['POLYGON_WS_URL'] = endpoint
             self.data_ws = polygon.StreamConn(
                 self._key_id + '-staging' if 'staging' in self._base_url else
                 self._key_id)


### PR DESCRIPTION
This will allow users to run more than one algorithm instance using the same websocket connection as described here:
https://github.com/shlomikushchi/alpaca-proxy-agent