### PR TITLE
Add note when using get_barset with limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ print(api.get_barset(['AAPL', 'GOOG'], 'minute', start=start, end=end).df)
 
 ```
 
+please note that if you are using limit, it is calculated from the end date. and if end date is not specified, "now" is used. <br>Take that under consideration when using start date with a limit. 
+
 ---
 
 ## StreamConn


### PR DESCRIPTION
When using get_barset() with limit, the count is from the end date
if end date is not specified, "now" is being used.
that could be confusing when using start date with limit and start date is something like (2016)
the user expects the data to be in 2016, if "now" is used, it will be only 2020 so the user need to be aware of that.