### PR TITLE
Convert session_open & session_close in Calendar entity to timestamp

### DIFF
--- a/alpaca_trade_api/entity.py
+++ b/alpaca_trade_api/entity.py
@@ -270,6 +270,8 @@ class Calendar(Entity):
                 return pd.Timestamp(val)
             elif key in ('open', 'close'):
                 return pd.Timestamp(val).time()
+            elif key in ('session_open', 'session_close'):
+                return pd.Timestamp(val[:2] + ':' + val[-2:]).time()
             else:
                 return val
         return super().__getattr__(key)


### PR DESCRIPTION
-Current Calendar entity receives session_close and session_open response from REST API (undocumented on alpaca docs)
-Response is in HHMM string format
-Convert HHMM to pd.Timestamp.time() object, consistent with other time data from the API