### PR TITLE
Fallback to use environment version

### DIFF
--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -170,7 +170,7 @@ class REST(object):
     def data_get(self, path, data=None):
         base_url: URL = get_data_url()
         return self._request(
-            'GET', path, data, base_url=base_url, api_version='v1'
+            'GET', path, data, base_url=base_url
         )
 
     def get_account(self) -> Account:


### PR DESCRIPTION
Setting v2 on the api or through an environment version is overridden by this when calling any api method.