### PR TITLE
chore(trades): added fields to trade mapping

### DIFF
--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -345,8 +345,12 @@ trade_mapping = {
     "s": "size",
     "t": "timestamp",
     "f": "trf_timestamp",
-    "y": "exchange_timestamp",
-    "e": "trade_correction"
+    "y": "participant_timestamp",
+    "e": "trade_correction",
+    "i": "id",
+    "r": "trf_id",
+    "q": "sequence_number",
+    "z": "tape"
 }
 
 quote_mapping = {

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -343,7 +343,10 @@ trade_mapping = {
     "x": "exchange",
     "p": "price",
     "s": "size",
-    "t": "timestamp"
+    "t": "timestamp",
+    "f": "trf_timestamp",
+    "y": "exchange_timestamp",
+    "e": "trade_correction"
 }
 
 quote_mapping = {


### PR DESCRIPTION
I added `f`, `y` and `e` to trades. Without this, these values would get lost in this mapping.