### PR TITLE
Updating Polygon Entity to allow pickle.load to work

### DIFF
--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -26,6 +26,12 @@ class Entity(object):
             raw=pprint.pformat(self._raw, indent=4),
         )
 
+    def __getstate__(self):
+        return self._raw
+
+    def __setstate__(self, state):
+        self._raw = state
+
 
 class Agg(Entity):
     def __getattr__(self, key):

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import pprint
 
+from collections import defaultdict
+
 NY = 'America/New_York'
 
 
@@ -93,14 +95,8 @@ class Aggsv2(list):
         ])
 
     def _raw_results(self):
-        results = self._raw.get('results')
-        if not results:
-            # this is not very pythonic but it's written like this because
-            # the raw response for empty aggs was None, and this:
-            # self._raw.get('results', []) returns None, not [] which breaks
-            # when we try to iterate it.
-            return []
-        return results
+        self._raw = self._raw or defaultdict(lambda: [])
+        return self._raw['results']
 
     def rename_keys(self):
         colmap = {


### PR DESCRIPTION
Currently, if you `pickle.dump` any Entity that's been initialized, and you try to `pickle.load` that object, you will receive an infinite regression. I've added following code so initialization on `pickle.load` works correctly. Not sure if this would be useful for anyone else who wants to save time with historical backtesting from data already loaded. 