### PR TITLE
Handle empty response from polygon when casting to entity

### DIFF
--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pprint
+from collections import defaultdict
 
 NY = 'America/New_York'
 
@@ -93,13 +94,14 @@ class Aggsv2(list):
         ])
 
     def _raw_results(self):
-        results = self._raw.get('results')
-        if not results:
-            # this is not very pythonic but it's written like this because
-            # the raw response for empty aggs was None, and this:
-            # self._raw.get('results', []) returns None, not [] which breaks
-            # when we try to iterate it.
-            return []
+        """
+        if self._raw is None, we can't access its attributes.
+        the first lines handles that.
+        if self._raw exists but it has no 'results' the second line will
+        handle that
+        """
+        self._raw = self._raw or defaultdict(lambda: [])
+        results = self._raw.get('results', [])
         return results
 
     def rename_keys(self):


### PR DESCRIPTION
we handle 2 cases:
self._raw is None
self._raw doesn't have property "results"

if any of these happen, we will returns an empty list 

