### PR TITLE
Limit pandas and numpy version to still support python 3.6

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,5 @@
-pandas  # pyup: ignore 
+pandas<1.2.0  # this package requires python 3.7
+numpy<1.20.0  # this package requires python 3.7
 requests>2,<3
 urllib3>1.24,<1.26
 websocket-client>=0.56.0,<1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
-pandas<1.2.0  # this package requires python 3.7
-numpy<1.20.0  # this package requires python 3.7
+pandas<1.2.0  # this package requires python 3.7 for higher versions
+numpy<1.20.0  # this package requires python 3.7 for higher versions
 requests>2,<3
 urllib3>1.24,<1.26
 websocket-client>=0.56.0,<1


### PR DESCRIPTION
pandas 1.2.0 and numpy 1.20.0 require python >= 3.7
we still want to support python 3.6