### PR TITLE
Loosen package versions to support python >= 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           path: test-reports_py2.7.13
           destination: test-reports2.7.13
 
-  build-python36:
+  build-test-python36:
     docker:
       - image: python:3.6.4
     working_directory: ~/repo
@@ -72,7 +72,7 @@ jobs:
           path: test-reports3.6.4
           destination: test-reports3.6.4
 
-  build-python37:
+  build-test-python37:
     docker:
       - image: python:3.7
     working_directory: ~/repo
@@ -143,7 +143,7 @@ workflows:
   build:
     jobs:
       # - build-python27
-      - build-python36
-      - build-python37
+      - build-test-python36
+      - build-test-python37
       - build-python38
       - build-python39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: run tests
           command: |
-            pip install pandas<1.2.0 numpy<1.20.0
+            pip install pandas==1.1.5 numpy==1.19.4
             python setup.py install
             pip install flake8 && flake8 alpaca_trade_api tests
             python setup.py test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,46 @@ jobs:
           path: test-reports3.6.4
           destination: test-reports3.6.4
 
+  build-python37:
+    docker:
+      - image: python:3.7
+    working_directory: ~/repo
+    steps:
+      - run: echo "hello python 3.7"
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "setup.py" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      # run tests!
+      # this example uses Django's built-in test-runner
+      # other common Python testing frameworks include pytest and nose
+      # https://pytest.org
+      # https://nose.readthedocs.io
+      - run:
+          name: run tests
+          command: |
+            python setup.py install
+            pip install flake8 && flake8 alpaca_trade_api tests
+            python setup.py test
+
+      - save_cache:
+          paths:
+            - ./eggs
+          key: v1-dependencies-{{ checksum "setup.py" }}
+
+      - store_artifacts:
+          path: test-reports3.7
+          destination: test-reports3.7
+
 workflows:
   version: 2
   build:
     jobs:
       # - build-python27
       - build-python36
+      - build-python37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,10 @@ jobs:
           name: make sure install works
           command: |
             python setup.py install
+      - run:
+          name: view installed packages
+          command: |
+            pip freeze
 
   build-python39:
     docker:
@@ -129,6 +133,10 @@ jobs:
           name: make sure install works
           command: |
             python setup.py install
+      - run:
+          name: view installed packages
+          command: |
+            pip freeze
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
       - run:
           name: run tests
           command: |
+            pip install pandas<1.2.0 numpy<1.20.0
             python setup.py install
             pip install flake8 && flake8 alpaca_trade_api tests
             python setup.py test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,28 @@ jobs:
           path: test-reports3.7
           destination: test-reports3.7
 
+  build-python38:
+    docker:
+      - image: python:3.8
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: make sure install works
+          command: |
+            python setup.py install
+
+  build-python39:
+    docker:
+      - image: python:3.9
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: make sure install works
+          command: |
+            python setup.py install
+
 workflows:
   version: 2
   build:
@@ -115,3 +137,5 @@ workflows:
       # - build-python27
       - build-python36
       - build-python37
+      - build-python38
+      - build-python39

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ Note this module supports only python version 3.6 and above, due to
 the async/await and websockets module dependency.
 
 ## Install
+We support python 3.x. If you want to work with python < 3.7 please note that these package dropped support for python <3.7 for the following versions:
+```
+pandas >= 1.2.0
+numpy >= 1.20.0
+scipy >= 1.6.0
+```
+The solution - manually install these package before installing alpaca-trade-api. e.g:
+```
+pip install pandas==1.1.5 numpy==1.19.4 scipy==1.5.4
+```
 
 ```bash
 $ pip3 install alpaca-trade-api

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
-pandas<1.2.0  # this package requires python 3.7 for higher versions
-numpy<1.20.0  # this package requires python 3.7 for higher versions
+pandas
+numpy
 requests>2,<3
-urllib3>1.24,<1.26
+urllib3>1.24,<2
 websocket-client>=0.56.0,<1
 websockets>=8.0,<9


### PR DESCRIPTION
* Instead of limiting versions of pandas and numpy to still support python 3.6 (pandas 1.2.0 and numpy 1.20.0 dropped support for python 3.6) we solve this by installing exact pandas and numpy when using python 3.6 on circle ci.

* Also added doc string to explain how to install properly with python 3.6
* Added python 3.7 build on circle ci (with latest pandas and numpy)
* added installation on python 3.8 & 3.9 (without tests) to make sure installation works smoothly