### PR TITLE
"Set not serializable" error for Python 3.8.7 json.dumps

### DIFF
--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -24,6 +24,7 @@ class Entity(object):
             raw=pprint.pformat(self._raw, indent=4),
         )
 
+
 class Agg(Entity):
     def __getattr__(self, key):
         if key in self._raw:

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -23,6 +23,7 @@ class Entity(object):
             name=self.__class__.__name__,
             raw=pprint.pformat(self._raw, indent=4),
         )
+    
 
 class Agg(Entity):
     def __getattr__(self, key):
@@ -92,8 +93,14 @@ class Aggsv2(list):
         ])
 
     def _raw_results(self):
-        self._raw = self._raw or defaultdict(lambda: [])
-        return self._raw['results']
+        results = self._raw.get('results')
+        if not results:
+            # this is not very pythonic but it's written like this because
+            # the raw response for empty aggs was None, and this:
+            # self._raw.get('results', []) returns None, not [] which breaks
+            # when we try to iterate it.
+            return []
+        return results
 
     def rename_keys(self):
         colmap = {

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -23,7 +23,6 @@ class Entity(object):
             name=self.__class__.__name__,
             raw=pprint.pformat(self._raw, indent=4),
         )
-    
 
 class Agg(Entity):
     def __getattr__(self, key):

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pprint
 
-from collections import defaultdict
-
 NY = 'America/New_York'
 
 
@@ -25,13 +23,6 @@ class Entity(object):
             name=self.__class__.__name__,
             raw=pprint.pformat(self._raw, indent=4),
         )
-
-    def __getstate__(self):
-        return self._raw
-
-    def __setstate__(self, state):
-        self._raw = state
-
 
 class Agg(Entity):
     def __getattr__(self, key):

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -26,6 +26,12 @@ class Entity(object):
             raw=pprint.pformat(self._raw, indent=4),
         )
 
+    def __getstate__(self):
+        return self._raw
+
+    def __setstate__(self, state):
+        self._raw = state
+
 
 class Agg(Entity):
     def __getattr__(self, key):

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import pprint
 
+from collections import defaultdict
+
 NY = 'America/New_York'
 
 
@@ -93,14 +95,8 @@ class Aggsv2(list):
         ])
 
     def _raw_results(self):
-        results = self._raw.get('results')
-        if not results:
-            # this is not very pythonic but it's written like this because
-            # the raw response for empty aggs was None, and this:
-            # self._raw.get('results', []) returns None, not [] which breaks
-            # when we try to iterate it.
-            return []
-        return results
+        self._raw = self._raw or defaultdict(lambda: [])
+        return self._raw['results']
 
     def rename_keys(self):
         colmap = {

--- a/alpaca_trade_api/polygon/streamconn.py
+++ b/alpaca_trade_api/polygon/streamconn.py
@@ -153,7 +153,7 @@ class StreamConn(object):
             self._streams |= set(channels)
             await self._ws.send(json.dumps({
                 'action': 'subscribe',
-                'params': streams
+                'params': list(streams)
             }))
 
     async def unsubscribe(self, channels):
@@ -167,7 +167,7 @@ class StreamConn(object):
             self._streams -= set(channels)
             await self._ws.send(json.dumps({
                 'action': 'unsubscribe',
-                'params': streams
+                'params': list(streams)
             }))
 
     def run(self, initial_channels=[]):

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -104,6 +104,8 @@ class _StreamConn(object):
     async def subscribe(self, channels):
         if isinstance(channels, str):
             channels = [channels]
+        if isinstance(channels, set):
+            channels = list(channels)
         if len(channels) > 0:
             await self._ensure_ws()
             self._streams |= set(channels)

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -104,15 +104,13 @@ class _StreamConn(object):
     async def subscribe(self, channels):
         if isinstance(channels, str):
             channels = [channels]
-        if isinstance(channels, set):
-            channels = list(channels)
         if len(channels) > 0:
             await self._ensure_ws()
             self._streams |= set(channels)
             await self._ws.send(json.dumps({
                 'action': 'listen',
                 'data': {
-                    'streams': channels,
+                    'streams': list(channels),
                 }
             }))
 
@@ -123,7 +121,7 @@ class _StreamConn(object):
             await self._ws.send(json.dumps({
                 'action': 'unlisten',
                 'data': {
-                    'streams': channels,
+                    'streams': list(channels),
                 }
             }))
 


### PR DESCRIPTION
With Python 3.8.7, I receive `TypeError: Object of type set is not JSON serializable` exception when `_StreamConn` tries to `json.dump` the channels after `suscribe()` is called with `self._streams` in `_ensure_ws()` 

`list(channels)` should always be serializable.  