### PR TITLE
Always serialize channels and streams as list

### DIFF
--- a/alpaca_trade_api/polygon/streamconn.py
+++ b/alpaca_trade_api/polygon/streamconn.py
@@ -153,7 +153,7 @@ class StreamConn(object):
             self._streams |= set(channels)
             await self._ws.send(json.dumps({
                 'action': 'subscribe',
-                'params': streams
+                'params': list(streams)
             }))
 
     async def unsubscribe(self, channels):
@@ -167,7 +167,7 @@ class StreamConn(object):
             self._streams -= set(channels)
             await self._ws.send(json.dumps({
                 'action': 'unsubscribe',
-                'params': streams
+                'params': list(streams)
             }))
 
     def run(self, initial_channels=[]):

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -118,7 +118,7 @@ class _StreamConn(object):
             await self._ws.send(json.dumps({
                 'action': 'listen',
                 'data': {
-                    'streams': channels,
+                    'streams': list(channels),
                 }
             }))
 
@@ -129,7 +129,7 @@ class _StreamConn(object):
             await self._ws.send(json.dumps({
                 'action': 'unlisten',
                 'data': {
-                    'streams': channels,
+                    'streams': list(channels),
                 }
             }))
 


### PR DESCRIPTION
On Python 3.8.7, I am receiving `TypeError: Object of type set is not JSON serializable` when a broken connection is trying to be reestablished. 