### PR TITLE
get and set state in a way that makes Entity pickleable

### DIFF
--- a/alpaca_trade_api/entity.py
+++ b/alpaca_trade_api/entity.py
@@ -34,6 +34,12 @@ class Entity(object):
             raw=pprint.pformat(self._raw, indent=4),
         )
 
+    def __getstate__(self):
+        return self._raw
+
+    def __setstate__(self, state):
+        self._raw = state
+
 
 class Account(Entity):
     """

--- a/alpaca_trade_api/polygon/entity.py
+++ b/alpaca_trade_api/polygon/entity.py
@@ -25,6 +25,12 @@ class Entity(object):
             raw=pprint.pformat(self._raw, indent=4),
         )
 
+    def __getstate__(self):
+        return self._raw
+
+    def __setstate__(self, state):
+        self._raw = state
+
 
 class Agg(Entity):
     def __getattr__(self, key):


### PR DESCRIPTION
This solution prevents an infinite regression when setting `_raw` during deserialization of a `pickle.dump` using `pickle.load` for a collection of `Entity` objects.