### PR TITLE
Enable raw data response without Entity wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,13 @@ The steps to execute this are:
 * execute your algorithm. it will connect to the servers through the proxy agent allowing you to execute multiple strategies
 
 
+## Raw Data vs Entity Data
+By default the data returned from the api or streamed via StreamConn is wrapped with an Entity object for ease of use.<br>
+Some users may prefer working with raw python objects (lists, dicts, ...). <br>You have 2 options to get the raw data:
+* Each Entity object as a `_raw` property that extract the raw data from the object.
+* If you only want to work with raw data, and avoid casting to Entity (which may take more time, casting back and forth) <br>you could pass `raw_data` argument
+  to `Rest()` object or the `StreamConn()` object.
+
 ## Support and Contribution
 
 For technical issues particular to this module, please report the

--- a/alpaca_trade_api/polygon/rest.py
+++ b/alpaca_trade_api/polygon/rest.py
@@ -4,7 +4,7 @@ from typing import List
 import dateutil.parser
 import requests
 from .entity import (
-    Aggsv2, Aggsv2Set, Trade, TradesV2, Quote, QuotesV2,
+    Entity, Aggsv2, Aggsv2Set, Trade, TradesV2, Quote, QuotesV2,
     Exchange, SymbolTypeMap, ConditionMap, Company, Dividends, Splits,
     Earnings, Financials, NewsList, Ticker, DailyOpenClose, Symbol
 )
@@ -92,9 +92,18 @@ def fix_daily_bar_date(date, timespan):
 
 class REST(object):
 
-    def __init__(self, api_key: str, staging: bool = False):
+    def __init__(self, api_key: str,
+                 staging: bool = False,
+                 raw_data: bool = False
+                 ):
+        """
+        :param staging: do we work with the staging server
+        :param raw_data: should we return api response raw or wrap it with
+                         Entity objects.
+        """
         self._api_key: str = get_polygon_credentials(api_key)
         self._staging: bool = staging
+        self._use_raw_data: bool = raw_data
         self._session = requests.Session()
 
     def _request(self, method: str, path: str, params: dict = None,
@@ -120,11 +129,15 @@ class REST(object):
 
     def exchanges(self) -> Exchanges:
         path = '/meta/exchanges'
-        return [Exchange(o) for o in self.get(path)]
+        resp = self.get(path)
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Exchange) for o in resp]
 
     def symbol_type_map(self) -> SymbolTypeMap:
         path = '/meta/symbol-types'
-        return SymbolTypeMap(self.get(path))
+        return self.response_wrapper(self.get(path), SymbolTypeMap)
 
     def historic_trades_v2(self,
                            symbol: str,
@@ -154,9 +167,8 @@ class REST(object):
             params['reverse'] = reverse
         if limit is not None:
             params['limit'] = limit
-        raw = self.get(path, params, 'v2')
-
-        return TradesV2(raw)
+        resp = self.get(path, params, 'v2')
+        return self.response_wrapper(resp, TradesV2)
 
     def historic_quotes_v2(self,
                            symbol: str,
@@ -186,9 +198,8 @@ class REST(object):
             params['reverse'] = reverse
         if limit is not None:
             params['limit'] = limit
-        raw = self.get(path, params, 'v2')
-
-        return QuotesV2(raw)
+        resp = self.get(path, params, 'v2')
+        return self.response_wrapper(resp, QuotesV2)
 
     def historic_agg_v2(self,
                         symbol: str,
@@ -226,39 +237,39 @@ class REST(object):
         params = {'unadjusted': unadjusted}
         if limit:
             params['limit'] = limit
-        raw = self.get(path, params, version='v2')
-        return Aggsv2(raw)
+        resp = self.get(path, params, version='v2')
+        return self.response_wrapper(resp, Aggsv2)
 
     def grouped_daily(self, date, unadjusted: bool = False) -> Aggsv2Set:
         path = f'/aggs/grouped/locale/us/market/stocks/{date}'
         params = {'unadjusted': unadjusted}
-        raw = self.get(path, params, version='v2')
-        return Aggsv2Set(raw)
+        resp = self.get(path, params, version='v2')
+        return self.response_wrapper(resp, Aggsv2Set)
 
     def daily_open_close(self, symbol: str, date) -> DailyOpenClose:
         path = f'/open-close/{symbol}/{date}'
-        raw = self.get(path)
-        return DailyOpenClose(raw)
+        resp = self.get(path)
+        return self.response_wrapper(resp, DailyOpenClose)
 
     def last_trade(self, symbol: str) -> Trade:
         path = '/last/stocks/{}'.format(symbol)
-        raw = self.get(path)
-        return Trade(raw['last'])
+        resp = self.get(path)['last']
+        return self.response_wrapper(resp, Trade)
 
     def last_quote(self, symbol: str) -> Quote:
         path = '/last_quote/stocks/{}'.format(symbol)
-        raw = self.get(path)
+        resp = self.get(path)['last']
         # TODO status check
-        return Quote(raw['last'])
+        return self.response_wrapper(resp, Quote)
 
     def previous_day_bar(self, symbol: str) -> Aggsv2:
         path = '/aggs/ticker/{}/prev'.format(symbol)
-        raw = self.get(path, version='v2')
-        return Aggsv2(raw)
+        resp = self.get(path, version='v2')
+        return self.response_wrapper(resp, Aggsv2)
 
     def condition_map(self, ticktype='trades') -> ConditionMap:
         path = '/meta/conditions/{}'.format(ticktype)
-        return ConditionMap(self.get(path))
+        return self.response_wrapper(self.get(path), ConditionMap)
 
     def company(self, symbol: str) -> Company:
         return self._get_symbol(symbol, 'company', Company)
@@ -275,7 +286,10 @@ class REST(object):
         res = self.get(path, params=params)
         if isinstance(res, list):
             res = {o['symbol']: o for o in res}
-        retmap = {sym: entity(res[sym]) for sym in symbols if sym in res}
+        if self._use_raw_data:
+            retmap = res
+        else:
+            retmap = {sym: entity(res[sym]) for sym in symbols if sym in res}
         if not multi:
             return retmap.get(symbol)
         return retmap
@@ -303,26 +317,28 @@ class REST(object):
                   "type": report_type.name,
                   "sort":  sort.value,
                   }
-        return Financials(self.get(path, version='v2',
-                                   params=params)['results'])
+        resp = self.get(path, version='v2', params=params)['results']
+        return self.response_wrapper(resp, Financials)
 
     def news(self, symbol: str) -> NewsList:
         path = '/meta/symbols/{}/news'.format(symbol)
-        return NewsList(self.get(path))
+        return self.response_wrapper(self.get(path), NewsList)
 
     def gainers_losers(self, direction: str = "gainers") -> Tickers:
         path = '/snapshot/locale/us/markets/stocks/{}'.format(direction)
-        return [
-            Ticker(ticker) for ticker in
-            self.get(path, version='v2')['tickers']
-        ]
+        resp = self.get(path, version='v2')['tickers']
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Ticker) for o in resp]
 
     def all_tickers(self) -> Tickers:
         path = '/snapshot/locale/us/markets/stocks/tickers'
-        return [
-            Ticker(ticker) for ticker in
-            self.get(path, version='v2')['tickers']
-        ]
+        resp = self.get(path, version='v2')['tickers']
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Ticker) for o in resp]
 
     def symbol_list_paginated(self, page: int = 1,
                               per_page: int = 50) -> Symbols:
@@ -334,15 +350,35 @@ class REST(object):
         :return:
         """
         path = '/reference/tickers'
-        return [Symbol(s) for s in self.get(path,
-                                            version='v2',
-                                            params={
-                                                "page": page,
-                                                "active": "true",
-                                                "perpage": per_page,
-                                                "market": "STOCKS"
-                                            })['tickers']]
+        resp = self.get(path,
+                        version='v2',
+                        params={
+                            "page": page,
+                            "active": "true",
+                            "perpage": per_page,
+                            "market": "STOCKS"
+                        })['tickers']
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Symbol) for o in resp]
 
     def snapshot(self, symbol: str) -> Ticker:
         path = '/snapshot/locale/us/markets/stocks/tickers/{}'.format(symbol)
-        return Ticker(self.get(path, version='v2'))
+        resp = self.get(path, version='v2')
+        return self.response_wrapper(resp, Ticker)
+
+
+    def response_wrapper(self, obj, entity: Entity):
+        """
+        To allow the user to get raw response from the api, we wrap all
+        functions with this method, checking if the user has set raw_data
+        bool. if they didn't, we wrap the response with an Entity object.
+        :param obj: response from server
+        :param entity: derivative object of Entity
+        :return:
+        """
+        if self._use_raw_data:
+            return obj
+        else:
+            return entity(obj)

--- a/alpaca_trade_api/polygon/rest.py
+++ b/alpaca_trade_api/polygon/rest.py
@@ -368,7 +368,6 @@ class REST(object):
         resp = self.get(path, version='v2')
         return self.response_wrapper(resp, Ticker)
 
-
     def response_wrapper(self, obj, entity: Entity):
         """
         To allow the user to get raw response from the api, we wrap all

--- a/alpaca_trade_api/polygon/rest.py
+++ b/alpaca_trade_api/polygon/rest.py
@@ -299,7 +299,8 @@ class REST(object):
 
     def splits(self, symbol: str) -> Splits:
         path = f'/reference/splits/{symbol}'
-        return Splits(self.get(path, version='v2')['results'])
+        resp = self.get(path, version='v2')['results']
+        return self.response_wrapper(resp, Splits)
 
     def earnings(self, symbol: str) -> Earnings:
         return self._get_symbol(symbol, 'earnings', Earnings)

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -86,7 +86,7 @@ class REST(object):
         self._retry_codes = [int(o) for o in os.environ.get(
             'APCA_RETRY_CODES', '429,504').split(',')]
         self.polygon = polygon.REST(
-            self._key_id, 'staging' in self._base_url)
+            self._key_id, 'staging' in self._base_url, self._use_raw_data)
 
     def _request(self,
                  method,

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -71,6 +71,10 @@ class REST(object):
                  oauth=None,
                  raw_data: bool = False
                  ):
+        """
+        :param raw_data: should we return api response raw or wrap it with
+                         Entity objects.
+        """
         self._key_id, self._secret_key, self._oauth = get_credentials(
             key_id, secret_key, oauth)
         self._base_url: URL = URL(base_url or get_base_url())
@@ -659,7 +663,6 @@ class REST(object):
             params['extended_hours'] = extended_hours
         resp = self.get('/account/portfolio/history', data=params)
         return self.response_wrapper(resp, PortfolioHistory)
-
 
     def __enter__(self):
         return self

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -11,7 +11,7 @@ from .common import (
     get_api_version, URL, FLOAT,
 )
 from .entity import (
-    Account, AccountConfigurations, AccountActivity,
+    Entity, Account, AccountConfigurations, AccountActivity,
     Asset, Order, Position, BarSet, Clock, Calendar,
     Aggs, Trade, Quote, Watchlist, PortfolioHistory
 )
@@ -68,13 +68,15 @@ class REST(object):
                  secret_key: str = None,
                  base_url: URL = None,
                  api_version: str = None,
-                 oauth=None
+                 oauth=None,
+                 raw_data: bool = False
                  ):
         self._key_id, self._secret_key, self._oauth = get_credentials(
             key_id, secret_key, oauth)
         self._base_url: URL = URL(base_url or get_base_url())
         self._api_version = get_api_version(api_version)
         self._session = requests.Session()
+        self._use_raw_data = raw_data
         self._retry = int(os.environ.get('APCA_RETRY_MAX', 3))
         self._retry_wait = int(os.environ.get('APCA_RETRY_WAIT', 3))
         self._retry_codes = [int(o) for o in os.environ.get(
@@ -176,12 +178,12 @@ class REST(object):
     def get_account(self) -> Account:
         """Get the account"""
         resp = self.get('/account')
-        return Account(resp)
+        return self.response_wrapper(resp, Account)
 
     def get_account_configurations(self) -> AccountConfigurations:
         """Get account configs"""
         resp = self.get('/account/configurations')
-        return AccountConfigurations(resp)
+        return self.response_wrapper(resp, AccountConfigurations)
 
     def update_account_configurations(
             self,
@@ -205,7 +207,7 @@ class REST(object):
         if suspend_trade is not None:
             params['suspend_trade'] = suspend_trade
         resp = self.patch('/account/configurations', params)
-        return AccountConfigurations(resp)
+        return self.response_wrapper(resp, AccountConfigurations)
 
     def list_orders(self,
                     status: str = None,
@@ -242,7 +244,10 @@ class REST(object):
             params['nested'] = nested
         url = '/orders'
         resp = self.get(url, params)
-        return [Order(o) for o in resp]
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Order) for o in resp]
 
     def submit_order(self,
                      symbol: str,
@@ -311,7 +316,7 @@ class REST(object):
         if trail_percent is not None:
             params['trail_percent'] = trail_percent
         resp = self.post('/orders', params)
-        return Order(resp)
+        return self.response_wrapper(resp, Order)
 
     def get_order_by_client_order_id(self, client_order_id: str) -> Order:
         """Get an order by client order id"""
@@ -319,7 +324,7 @@ class REST(object):
             'client_order_id': client_order_id,
         }
         resp = self.get('/orders:by_client_order_id', params)
-        return Order(resp)
+        return self.response_wrapper(resp, Order)
 
     def get_order(self, order_id: str, nested: bool = None) -> Order:
         """Get an order"""
@@ -327,7 +332,7 @@ class REST(object):
         if nested is not None:
             params['nested'] = nested
         resp = self.get('/orders/{}'.format(order_id), params)
-        return Order(resp)
+        return self.response_wrapper(resp, Order)
 
     def replace_order(
             self,
@@ -365,7 +370,7 @@ class REST(object):
         if client_order_id is not None:
             params['client_order_id'] = client_order_id
         resp = self.patch('/orders/{}'.format(order_id), params)
-        return Order(resp)
+        return self.response_wrapper(resp, Order)
 
     def cancel_order(self, order_id: str) -> None:
         """Cancel an order"""
@@ -378,22 +383,28 @@ class REST(object):
     def list_positions(self) -> Positions:
         """Get a list of open positions"""
         resp = self.get('/positions')
-        return [Position(o) for o in resp]
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(p, Position) for p in resp]
 
     def get_position(self, symbol: str) -> Position:
         """Get an open position"""
         resp = self.get('/positions/{}'.format(symbol))
-        return Position(resp)
+        return self.response_wrapper(resp, Position)
 
-    def close_position(self, symbol: str) -> Order:
+    def close_position(self, symbol: str) -> Position:
         """Liquidates the position for the given symbol at market price"""
         resp = self.delete('/positions/{}'.format(symbol))
-        return Order(resp)
+        return self.response_wrapper(resp, Position)
 
-    def close_all_positions(self) -> Orders:
+    def close_all_positions(self) -> Positions:
         """Liquidates all open positions at market price"""
         resp = self.delete('/positions')
-        return [Order(o) for o in resp]
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Position) for o in resp]
 
     def list_assets(self, status=None, asset_class=None) -> Assets:
         """Get a list of assets"""
@@ -402,12 +413,15 @@ class REST(object):
             'asset_class': asset_class,
         }
         resp = self.get('/assets', params)
-        return [Asset(o) for o in resp]
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Asset) for o in resp]
 
     def get_asset(self, symbol: str) -> Asset:
         """Get an asset"""
         resp = self.get('/assets/{}'.format(symbol))
-        return Asset(resp)
+        return self.response_wrapper(resp, Asset)
 
     def get_barset(self,
                    symbols,
@@ -453,7 +467,7 @@ class REST(object):
         if until is not None:
             params['until'] = until
         resp = self.data_get('/bars/{}'.format(timeframe), params)
-        return BarSet(resp)
+        return self.response_wrapper(resp, BarSet)
 
     def get_aggs(self,
                  symbol: str,
@@ -473,23 +487,23 @@ class REST(object):
         resp = self.data_get('/aggs/ticker/{}/range/{}/{}/{}/{}'.format(
             symbol, multiplier, timespan, _from, to
         ))
-        return Aggs(resp)
+        return self.response_wrapper(resp, Aggs)
 
     def get_last_trade(self, symbol: str) -> Trade:
         """
         Get the last trade for the given symbol
         """
         resp = self.data_get('/last/stocks/{}'.format(symbol))
-        return Trade(resp['last'])
+        return self.response_wrapper(resp['last'], Trade)
 
     def get_last_quote(self, symbol: str) -> Quote:
         """Get the last trade for the given symbol"""
         resp = self.data_get('/last_quote/stocks/{}'.format(symbol))
-        return Quote(resp['last'])
+        return self.response_wrapper(resp['last'], Quote)
 
     def get_clock(self) -> Clock:
         resp = self.get('/clock')
-        return Clock(resp)
+        return self.response_wrapper(resp, Clock)
 
     def get_activities(
             self,
@@ -531,7 +545,10 @@ class REST(object):
         if page_token is not None:
             params['page_token'] = page_token
         resp = self.get(url, data=params)
-        return [AccountActivity(o) for o in resp]
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, AccountActivity) for o in resp]
 
     def get_calendar(self, start: str = None, end: str = None) -> Calendars:
         """
@@ -545,17 +562,23 @@ class REST(object):
         if end is not None:
             params['end'] = end
         resp = self.get('/calendar', data=params)
-        return [Calendar(o) for o in resp]
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Calendar) for o in resp]
 
     def get_watchlists(self) -> Watchlists:
         """Get the list of watchlists registered under the account"""
         resp = self.get('/watchlists')
-        return [Watchlist(o) for o in resp]
+        if self._use_raw_data:
+            return resp
+        else:
+            return [self.response_wrapper(o, Watchlist) for o in resp]
 
     def get_watchlist(self, watchlist_id: str) -> Watchlist:
         """Get a watchlist identified by the ID"""
         resp = self.get('/watchlists/{}'.format((watchlist_id)))
-        return Watchlist(resp)
+        return self.response_wrapper(resp, Watchlist)
 
     def get_watchlist_by_name(self, watchlist_name: str) -> Watchlist:
         """Get a watchlist identified by its name"""
@@ -563,7 +586,7 @@ class REST(object):
             'name': watchlist_name,
         }
         resp = self.get('/watchlists:by_name', data=params)
-        return Watchlist(resp)
+        return self.response_wrapper(resp, Watchlist)
 
     def create_watchlist(self,
                          watchlist_name: str,
@@ -575,14 +598,14 @@ class REST(object):
         if symbols is not None:
             params['symbols'] = symbols
         resp = self.post('/watchlists', data=params)
-        return Watchlist(resp)
+        return self.response_wrapper(resp, Watchlist)
 
     def add_to_watchlist(self, watchlist_id: str, symbol: str) -> Watchlist:
         """Add an asset to the watchlist"""
         resp = self.post(
             '/watchlists/{}'.format(watchlist_id), data=dict(symbol=symbol)
         )
-        return Watchlist(resp)
+        return self.response_wrapper(resp, Watchlist)
 
     def update_watchlist(self,
                          watchlist_id: str,
@@ -595,7 +618,7 @@ class REST(object):
         if symbols is not None:
             params['symbols'] = symbols
         resp = self.put('/watchlists/{}'.format(watchlist_id), data=params)
-        return Watchlist(resp)
+        return self.response_wrapper(resp, Watchlist)
 
     def delete_watchlist(self, watchlist_id: str) -> None:
         """Delete a watchlist identified by the ID permanently"""
@@ -634,9 +657,9 @@ class REST(object):
             params['timeframe'] = timeframe
         if extended_hours is not None:
             params['extended_hours'] = extended_hours
-        return PortfolioHistory(
-            self.get('/account/portfolio/history', data=params)
-        )
+        resp = self.get('/account/portfolio/history', data=params)
+        return self.response_wrapper(resp, PortfolioHistory)
+
 
     def __enter__(self):
         return self
@@ -646,3 +669,17 @@ class REST(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+
+    def response_wrapper(self, obj, entity: Entity):
+        """
+        To allow the user to get raw response from the api, we wrap all
+        functions with this method, checking if the user has set raw_data
+        bool. if they didn't, we wrap the response with an Entity object.
+        :param obj: response from server
+        :param entity: derivative object of Entity
+        :return:
+        """
+        if self._use_raw_data:
+            return obj
+        else:
+            return entity(obj)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -22,6 +22,8 @@ def reqmock():
 
 def test_api(reqmock):
     api = tradeapi.REST('key-id', 'secret-key', api_version='v1')
+    api_raw = tradeapi.REST('key-id', 'secret-key', api_version='v1',
+                            raw_data=True)
 
     # Get a list of accounts
     reqmock.get('https://api.alpaca.markets/v1/account', text='''
@@ -43,6 +45,8 @@ def test_api(reqmock):
     account = api.get_account()
     assert account.status == 'ACTIVE'
     assert 'Account(' in str(account)
+    assert type(account) == tradeapi.entity.Account
+    assert type(api_raw.get_account()) == dict
 
     # Get a list of assets
     reqmock.get('https://api.alpaca.markets/v1/assets', text='''[
@@ -58,6 +62,8 @@ def test_api(reqmock):
 ]''')
     assets = api.list_assets()
     assert assets[0].name == 'Apple inc.'
+    assert type(assets[0]) == tradeapi.entity.Asset
+    assert type(api_raw.list_assets()) == list
 
     # Get an asset
     asset_id = '904837e3-3b76-47ec-b432-046db621571b'
@@ -73,10 +79,14 @@ def test_api(reqmock):
   }''')
     asset = api.get_asset(asset_id)
     assert asset.name == 'Apple inc.'
+    assert type(asset) == tradeapi.entity.Asset
+    assert type(api_raw.get_asset(asset_id)) == dict
 
 
 def test_orders(reqmock):
     api = tradeapi.REST('key-id', 'secret-key', api_version='v1')
+    api_raw = tradeapi.REST('key-id', 'secret-key', api_version='v1',
+                            raw_data=True)
 
     # Get a list of orders
     reqmock.get(
@@ -112,6 +122,8 @@ def test_orders(reqmock):
 ]''')
     orders = api.list_orders('all')
     assert orders[0].type == 'market'
+    assert type(orders[0]) == tradeapi.entity.Order
+    assert type(api_raw.list_orders()) == list
 
     # Create an order
     reqmock.post(
@@ -155,6 +167,16 @@ def test_orders(reqmock):
     )
     assert order.qty == "15"
     assert order.created_at.hour == 19
+    assert type(order) == tradeapi.entity.Order
+    assert type(api_raw.submit_order(
+        symbol='904837e3-3b76-47ec-b432-046db621571b',
+        qty=15,
+        side='buy',
+        type='market',
+        time_in_force='day',
+        limit_price='107.00',
+        stop_price='106.00',
+        client_order_id='904837e3-3b76-47ec-b432-046db621571b',)) == dict
     # now let's test some different acceptable "float" formats
     api.submit_order(
         symbol='904837e3-3b76-47ec-b432-046db621571b',
@@ -233,6 +255,8 @@ def test_orders(reqmock):
 }''')
     order = api.get_order_by_client_order_id(client_order_id)
     assert order.submitted_at.minute == 50
+    assert type(order) == tradeapi.entity.Order
+    assert type(api_raw.get_order_by_client_order_id(client_order_id)) == dict
 
     # Get an order
     order_id = '904837e3-3b76-47ec-b432-046db621571b'
@@ -268,6 +292,8 @@ def test_orders(reqmock):
     )
     order = api.get_order(order_id)
     assert order.side == 'buy'
+    assert type(order) == tradeapi.entity.Order
+    assert type(api_raw.get_order(order_id)) == dict
 
     # Cancel an order
     order_id = '904837e3-3b76-47ec-b432-046db621571b'
@@ -281,6 +307,8 @@ def test_orders(reqmock):
 
 def test_positions(reqmock):
     api = tradeapi.REST('key-id', 'secret-key', api_version='v1')
+    api_raw = tradeapi.REST('key-id', 'secret-key', api_version='v1',
+                            raw_data=True)
 
     # Get a list of positions
     reqmock.get(
@@ -300,6 +328,8 @@ def test_positions(reqmock):
     )
     positions = api.list_positions()
     assert positions[0].entry_price == '100.0'
+    assert type(positions[0]) == tradeapi.entity.Position
+    assert type(api_raw.list_positions()) == list
 
     # Get an open position
     asset_id = 'test-asset'
@@ -318,10 +348,14 @@ def test_positions(reqmock):
     )
     position = api.get_position(asset_id)
     assert position.cost_basis == '500.0'
+    assert type(position) == tradeapi.entity.Position
+    assert type(api_raw.get_position(asset_id)) == dict
 
 
 def test_chronos(reqmock):
     api = tradeapi.REST('key-id', 'secret-key', api_version='v1')
+    api_raw = tradeapi.REST('key-id', 'secret-key', api_version='v1',
+                            raw_data=True)
 
     # clock
     reqmock.get(
@@ -336,6 +370,8 @@ def test_chronos(reqmock):
     clock = api.get_clock()
     assert clock.is_open
     assert clock.next_open.day == 1
+    assert type(clock) == tradeapi.entity.Clock
+    assert type(api_raw.get_clock()) == dict
 
     # calendar
     reqmock.get(
@@ -351,10 +387,15 @@ def test_chronos(reqmock):
     calendar = api.get_calendar(start='2018-01-03')
     assert calendar[0].date.day == 3
     assert calendar[0].open.minute == 30
+    assert type(calendar) == list
+    assert type(calendar[0]) == tradeapi.entity.Calendar
+    assert type(api_raw.get_calendar(start='2018-01-03')) == list
 
 
 def test_data(reqmock):
     api = tradeapi.REST('key-id', 'secret-key', api_version='v1')
+    api_raw = tradeapi.REST('key-id', 'secret-key', api_version='v1',
+                            raw_data=True)
     # Bars
     reqmock.get(
         'https://data.alpaca.markets/v1/bars/1D?symbols=AAPL,TSLA&limit=2',
@@ -389,6 +430,8 @@ def test_data(reqmock):
     assert barset['TSLA'][1].h == 346.22
     assert barset['AAPL'][0].t.day == 23
     assert barset['AAPL'].df.index[0].day == 23
+    assert type(barset) == tradeapi.entity.BarSet
+    assert type(api_raw.get_barset('AAPL,TSLA', '1D', limit=2)) == dict
 
     # Aggs
     reqmock.get(
@@ -436,6 +479,9 @@ def test_data(reqmock):
     assert len(aggs) == 3
     assert aggs[0].open == 314.18
     assert aggs.df.iloc[1].high == 323.9
+    assert type(aggs) == tradeapi.entity.Aggs
+    assert type(api_raw.get_aggs(
+        'AAPL', 1, 'day', '2020-02-10', '2020-02-12')) == dict
     with pytest.raises(AttributeError):
         aggs[2].foo
 
@@ -462,6 +508,8 @@ def test_data(reqmock):
     trade = api.get_last_trade('AAPL')
     assert trade.price == 159.59
     assert trade.timestamp.day == 8
+    assert type(trade) == tradeapi.entity.Trade
+    assert type(api_raw.get_last_trade('AAPL')) == dict
 
     # Last quote
     reqmock.get(
@@ -485,10 +533,14 @@ def test_data(reqmock):
     quote = api.get_last_quote('AAPL')
     assert quote.askprice == 159.59
     assert quote.timestamp.day == 8
+    assert type(quote) == tradeapi.entity.Quote
+    assert type(api_raw.get_last_quote('AAPL')) == dict
 
 
 def test_watchlists(reqmock):
     api = tradeapi.REST('key-id', 'secret-key', api_version='v1')
+    api_raw = tradeapi.REST('key-id', 'secret-key', api_version='v1',
+                            raw_data=True)
     # get watchlists
     reqmock.get(
         'https://api.alpaca.markets/v1/watchlists',
@@ -519,6 +571,8 @@ def test_watchlists(reqmock):
     assert watchlists[0].name == 'Primary Watchlist'
     assert watchlists[1].id == 'e65f2f2d-b596-4db6-bd68-1b7ceb77cccc'
     assert watchlists[2].account_id == '1f893862-13b5-4603-b3ca-513980c00c6e'
+    assert type(watchlists[0]) == tradeapi.entity.Watchlist
+    assert type(api_raw.get_watchlists()) == list
 
     # get a watchlist by watchlist_id
     watchlist_id = "e65f2f2d-b596-4db6-bd68-1b7ceb77cccc"
@@ -595,6 +649,8 @@ def test_watchlists(reqmock):
     assert watchlist.assets[0]["marginable"]
     assert watchlist.assets[0]["shortable"]
     assert watchlist.assets[0]["easy_to_borrow"]
+    assert type(watchlist) == tradeapi.entity.Watchlist
+    assert type(api_raw.get_watchlist(watchlist_id)) == dict
 
     # add an asset to a watchlist
     reqmock.post(
@@ -624,6 +680,8 @@ def test_watchlists(reqmock):
     assert watchlist.name == 'Primary Watchlist'
     assert len(watchlist.assets) == 1
     assert watchlist.assets[0]["symbol"] == "AMD"
+    assert type(watchlist) == tradeapi.entity.Watchlist
+    assert type(api_raw.add_to_watchlist(watchlist_id, symbol="AMD")) == dict
 
     # remove an item from a watchlist
     reqmock.delete(
@@ -700,6 +758,8 @@ def test_watchlists(reqmock):
 
 def test_errors(reqmock):
     api = tradeapi.REST('key-id', 'secret-key', api_version='v1')
+    api_raw = tradeapi.REST('key-id', 'secret-key', api_version='v1',
+                            raw_data=True)
 
     api._retry = 1
     api._retry_wait = 0

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -758,8 +758,6 @@ def test_watchlists(reqmock):
 
 def test_errors(reqmock):
     api = tradeapi.REST('key-id', 'secret-key', api_version='v1')
-    api_raw = tradeapi.REST('key-id', 'secret-key', api_version='v1',
-                            raw_data=True)
 
     api._retry = 1
     api._retry_wait = 0


### PR DESCRIPTION
Some users may want to work with raw data received from the servers as json and not work with Entity objects.
This PR allows the user to choose what data he/she to work with.
It is done by passing a boolean called `raw_data` to the REST instances and the WS instance.
when doing so, there will be no casting to Entity objects once a response from the API is received,