### PR TITLE
fix: move StreamConn oauth arg to end of list

### DIFF
--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -190,11 +190,11 @@ class StreamConn(object):
             self,
             key_id: str = None,
             secret_key: str = None,
-            oauth: str = None,
             base_url: URL = None,
             data_url: URL = None,
             data_stream: str = None,
-            debug: bool = False
+            debug: bool = False,
+            oauth: str = None
     ):
         self._key_id, self._secret_key, self._oauth = \
             get_credentials(key_id, secret_key, oauth)


### PR DESCRIPTION
Even though it is better suited next to the api keys, when users don't use named args ( => kwargs)
this new order may break their usage. e.g:
```py
StreamConn(self._key_id,
                     self._secret_key,
                     self._base_url)
```
this will put the base_url inside `oauth`.
moving it to the end of the list will prevent this from happening.