### PR TITLE
Pass self._streams as a list to subscribe()

### DIFF
--- a/alpaca_trade_api/polygon/streamconn.py
+++ b/alpaca_trade_api/polygon/streamconn.py
@@ -124,7 +124,7 @@ class StreamConn(object):
             try:
                 await self.connect()
                 if self._streams:
-                    await self.subscribe(self._streams)
+                    await self.subscribe(list(self._streams))
                 break
             except Exception as e:
                 await self._dispatch({'ev': 'status',

--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -99,7 +99,7 @@ class _StreamConn(object):
             try:
                 await self._connect()
                 if self._streams:
-                    await self.subscribe(self._streams)
+                    await self.subscribe(list(self._streams))
                 break
             except websockets.WebSocketException as wse:
                 logging.warn(wse)


### PR DESCRIPTION
If the connection drops and it trys to reconnect, it fails because the channels are saved in self._streams, which is a set, which is not serializable in JSON, so convert it back to a list when passing the channels to _StreamConn.subscribe().