### PR TITLE
Fix issue where self._streams set is used as channels but cannot be s…

### DIFF
--- a/alpaca_trade_api/stream2.py
+++ b/alpaca_trade_api/stream2.py
@@ -123,6 +123,8 @@ class _StreamConn(object):
     async def subscribe(self, channels):
         if isinstance(channels, str):
             channels = [channels]
+        elif isinstance(channels, set):
+            channels = list(channels)
         if len(channels) > 0:
             await self._ensure_ws()
             self._streams |= set(channels)
@@ -136,6 +138,8 @@ class _StreamConn(object):
     async def unsubscribe(self, channels):
         if isinstance(channels, str):
             channels = [channels]
+        elif isinstance(channels, set):
+            channels = list(channels)
         if len(channels) > 0:
             await self._ws.send(json.dumps({
                 'action': 'unlisten',


### PR DESCRIPTION
Fix issue where self._streams set is used as channels but cannot be serialized.

When the websocket restarts due to closure, self._streams is used as channels but since it is a set, it cannot be serialized:

at alpaca-trade-api-python/alpaca_trade_api/stream2.py:100> exception=TypeError('Object of type set is not JSON serializable')> 
Traceback (most recent call last):
  File "/scm/alpaca-trade-api-python/alpaca_trade_api/stream2.py", line 108, in _ensure_ws
    await self.subscribe(self._streams)
  File "/scm/alpaca-trade-api-python/alpaca_trade_api/stream2.py", line 124, in subscribe
    await self._ws.send(json.dumps({
  File "/usr/local/lib/python3.9/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type set is not JSON serializable
