### PR TITLE
Added missing type hint py.typed files.

### DIFF
--- a/alpaca_trade_api/polygon/py.typed
+++ b/alpaca_trade_api/polygon/py.typed
@@ -1,0 +1,2 @@
+# Refer to PEP 561 for purpose of this file.
+# https://www.python.org/dev/peps/pep-0561/

--- a/alpaca_trade_api/py.typed
+++ b/alpaca_trade_api/py.typed
@@ -1,0 +1,2 @@
+# Refer to PEP 561 for purpose of this file.
+# https://www.python.org/dev/peps/pep-0561/

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,10 @@ setup(
         'alpaca_trade_api',
         'alpaca_trade_api.polygon',
     ],
+    package_data={
+        'alpaca_trade_api': ['py.typed'],
+        'alpaca_trade_api.polygon': ['py.typed'],
+    },
     install_requires=REQUIREMENTS,
     tests_require=REQUIREMENTS_TEST,
     setup_requires=['pytest-runner', 'flake8'],


### PR DESCRIPTION
In order for utilities like MyPy to take advantage of the type hints that in the package there need to be py.typed files installed with the package as per [PEP 651](https://www.python.org/dev/peps/pep-0561/)