### PR TITLE
Update the websockets package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The solution - manually install these package before installing alpaca-trade-api
 ```bash
 pip install pandas==1.1.5 numpy==1.19.4 scipy==1.5.4
 ```
+Also note that we do not limit the version of the websockets library, but we advice using
+```
+websockets>=9.0
+```
 
 Installing using pip
 ```bash

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,5 @@ numpy
 requests>2,<3
 urllib3>1.24,<2
 websocket-client>=0.56.0,<1
-websockets>=8.0,<9
+websockets>=8.0,<10
 msgpack==1.0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ pandas
 numpy
 requests>2,<3
 urllib3>1.24,<2
-websocket-client>=0.56.0,<1
+websocket-client>=0.56.0,<2
 websockets>=8.0,<10
 msgpack==1.0.2


### PR DESCRIPTION
The websockets package as a new major version. 
After reading the release notes and making sure nothing breaks, I suggest increasing allowed version of the package.

websocket-client 1.0 dropped support for python2. but we're ok with that.