### PR TITLE
Add support for closing partial position

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The solution - manually install these package before installing alpaca-trade-api
 ```bash
 pip install pandas==1.1.5 numpy==1.19.4 scipy==1.5.4
 ```
+Also note that we do not limit the version of the websockets library, but we advice using
+```
+websockets>=9.0
+```
 
 Installing using pip
 ```bash

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -108,8 +108,7 @@ class REST(object):
                  path,
                  data=None,
                  base_url: URL = None,
-                 api_version: str = None
-                 ):
+                 api_version: str = None):
         base_url = base_url or self._base_url
         version = api_version if api_version else self._api_version
         url: URL = URL(base_url + '/' + version + path)
@@ -127,7 +126,7 @@ class REST(object):
             # It's better to fail early if the URL isn't right.
             'allow_redirects': False,
         }
-        if method.upper() == 'GET':
+        if method.upper() in ['GET', 'DELETE']:
             opts['params'] = data
         else:
             opts['json'] = data
@@ -417,9 +416,24 @@ class REST(object):
         resp = self.get('/positions/{}'.format(symbol))
         return self.response_wrapper(resp, Position)
 
-    def close_position(self, symbol: str) -> Position:
+    def close_position(self, symbol: str, *,
+                       qty: float = None,
+                       # percentage: float = None  # currently unsupported api
+                       ) -> Position:
         """Liquidates the position for the given symbol at market price"""
-        resp = self.delete('/positions/{}'.format(symbol))
+        # if qty and percentage:
+        #     raise Exception("Can't close position with qty and pecentage")
+        # elif qty:
+        #     data = {'qty': qty}
+        # elif percentage:
+        #     data = {'percentage': percentage}
+        # else:
+        #     data = {}
+        if qty:
+            data = {'qty': qty}
+        else:
+            data = {}
+        resp = self.delete('/positions/{}'.format(symbol), data=data)
         return self.response_wrapper(resp, Position)
 
     def close_all_positions(self) -> Positions:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,5 @@ numpy
 requests>2,<3
 urllib3>1.24,<2
 websocket-client>=0.56.0,<1
-websockets>=8.0,<9
+websockets>=8.0,<10
 msgpack==1.0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ pandas
 numpy
 requests>2,<3
 urllib3>1.24,<2
-websocket-client>=0.56.0,<1
+websocket-client>=0.56.0,<2
 websockets>=8.0,<10
 msgpack==1.0.2


### PR DESCRIPTION
Add support for this API: https://alpaca.markets/docs/api-documentation/api-v2/positions/#close-a-position.
According to the docs one could specify partial fractional qty or percentage. 

percentage seems to be currently unsupported, so it is commented out and will be commented in once api supports it.

For now, one could close partial fractional qty like this: 

```py
api.close_position("AAPL", 0.5)
```

Read the docs for more details. 