### PR TITLE
Extend list_orders functionality with symbols filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ for trade in trades_iter:
 ### Live Stream Data
 There are 2 streams available as described [here](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/real-time/).<br>
 The free plan is using the `iex` stream, while the paid subscription is using the `sip` stream.<br>
-You could subscribe to bars, trades or quotes and accoutn updates as well.<br>
+You could subscribe to bars, trades or quotes and account updates as well.<br>
 Under the example folder you could find different code [samples](https://github.com/alpacahq/alpaca-trade-api-python/tree/master/examples/websockets) to achieve different goals. Let's see the basic example<br>
 We present a new Streamer class under `alpaca_trade_api.stream` for API V2.
 ```py

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The solution - manually install these package before installing alpaca-trade-api
 ```bash
 pip install pandas==1.1.5 numpy==1.19.4 scipy==1.5.4
 ```
+Also note that we do not limit the version of the websockets library, but we advice using
+```
+websockets>=9.0
+```
 
 Installing using pip
 ```bash

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -234,7 +234,9 @@ class REST(object):
                     until: str = None,
                     direction: str = None,
                     params=None,
-                    nested: bool = None) -> Orders:
+                    nested: bool = None,
+                    symbols: List[str] = None
+                    ) -> Orders:
         """
         Get a list of orders
         https://docs.alpaca.markets/web-api/orders/#get-a-list-of-orders
@@ -260,6 +262,8 @@ class REST(object):
             params['status'] = status
         if nested is not None:
             params['nested'] = nested
+        if symbols is not None:
+            params['symbols'] = ",".join(symbols)
         url = '/orders'
         resp = self.get(url, params)
         if self._use_raw_data:

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -108,8 +108,7 @@ class REST(object):
                  path,
                  data=None,
                  base_url: URL = None,
-                 api_version: str = None
-                 ):
+                 api_version: str = None):
         base_url = base_url or self._base_url
         version = api_version if api_version else self._api_version
         url: URL = URL(base_url + '/' + version + path)
@@ -127,7 +126,7 @@ class REST(object):
             # It's better to fail early if the URL isn't right.
             'allow_redirects': False,
         }
-        if method.upper() == 'GET':
+        if method.upper() in ['GET', 'DELETE']:
             opts['params'] = data
         else:
             opts['json'] = data
@@ -417,9 +416,24 @@ class REST(object):
         resp = self.get('/positions/{}'.format(symbol))
         return self.response_wrapper(resp, Position)
 
-    def close_position(self, symbol: str) -> Position:
+    def close_position(self, symbol: str, *,
+                       qty: float = None,
+                       # percentage: float = None  # currently unsupported api
+                       ) -> Position:
         """Liquidates the position for the given symbol at market price"""
-        resp = self.delete('/positions/{}'.format(symbol))
+        # if qty and percentage:
+        #     raise Exception("Can't close position with qty and pecentage")
+        # elif qty:
+        #     data = {'qty': qty}
+        # elif percentage:
+        #     data = {'percentage': percentage}
+        # else:
+        #     data = {}
+        if qty:
+            data = {'qty': qty}
+        else:
+            data = {}
+        resp = self.delete('/positions/{}'.format(symbol), data=data)
         return self.response_wrapper(resp, Position)
 
     def close_all_positions(self) -> Positions:

--- a/alpaca_trade_api/stream.py
+++ b/alpaca_trade_api/stream.py
@@ -234,7 +234,7 @@ class DataStream:
                     await self._start_ws()
                     self._running = True
                     retries = 0
-                    await self._consume()
+                await self._consume()
             except websockets.WebSocketException as wse:
                 retries += 1
                 if retries > int(os.environ.get('APCA_RETRY_MAX', 3)):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ pandas
 numpy
 requests>2,<3
 urllib3>1.24,<2
-websocket-client>=0.56.0,<1
-websockets>=8.0,<9
+websocket-client>=0.56.0,<2
+websockets>=8.0,<10
 msgpack==1.0.2


### PR DESCRIPTION
https://alpaca.markets/docs/api-documentation/api-v2/orders/#get-a-list-of-orders indicates you could use a list of symbols as filters. adding that as a param.

You could now run this code:

```py
api.list_orders(status="closed", symbols=["GOOG", "TSLA", "MSFT"])
```