### PR TITLE
Try to consume again when we get a connection error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The solution - manually install these package before installing alpaca-trade-api
 ```bash
 pip install pandas==1.1.5 numpy==1.19.4 scipy==1.5.4
 ```
+Also note that we do not limit the version of the websockets library, but we advice using
+```
+websockets>=9.0
+```
 
 Installing using pip
 ```bash

--- a/alpaca_trade_api/stream.py
+++ b/alpaca_trade_api/stream.py
@@ -234,7 +234,7 @@ class DataStream:
                     await self._start_ws()
                     self._running = True
                     retries = 0
-                    await self._consume()
+                await self._consume()
             except websockets.WebSocketException as wse:
                 retries += 1
                 if retries > int(os.environ.get('APCA_RETRY_MAX', 3)):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,5 @@ numpy
 requests>2,<3
 urllib3>1.24,<2
 websocket-client>=0.56.0,<1
-websockets>=8.0,<9
+websockets>=8.0,<10
 msgpack==1.0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,6 @@ pandas
 numpy
 requests>2,<3
 urllib3>1.24,<2
-websocket-client>=0.56.0,<1
+websocket-client>=0.56.0,<2
 websockets>=8.0,<10
 msgpack==1.0.2


### PR DESCRIPTION
3 retries by default

the way it was - there was never a retry, just a loop that runs forever if we get 1 connection error