### PR TITLE
Extend list_orders functionality with symbols filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ for trade in trades_iter:
 ### Live Stream Data
 There are 2 streams available as described [here](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/real-time/).<br>
 The free plan is using the `iex` stream, while the paid subscription is using the `sip` stream.<br>
-You could subscribe to bars, trades or quotes and accoutn updates as well.<br>
+You could subscribe to bars, trades or quotes and trade updates as well.<br>
 Under the example folder you could find different code [samples](https://github.com/alpacahq/alpaca-trade-api-python/tree/master/examples/websockets) to achieve different goals. Let's see the basic example<br>
 We present a new Streamer class under `alpaca_trade_api.stream` for API V2.
 ```py

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -235,7 +235,9 @@ class REST(object):
                     until: str = None,
                     direction: str = None,
                     params=None,
-                    nested: bool = None) -> Orders:
+                    nested: bool = None,
+                    symbols: List[str] = None
+                    ) -> Orders:
         """
         Get a list of orders
         https://docs.alpaca.markets/web-api/orders/#get-a-list-of-orders
@@ -246,6 +248,8 @@ class REST(object):
         :param until: timestamp
         :param direction: asc or desc.
         :param params: refer to documentation
+        :param nested: should the data be nested like json
+        :param symbols: list of str (symbols)
         """
         if params is None:
             params = dict()
@@ -261,6 +265,8 @@ class REST(object):
             params['status'] = status
         if nested is not None:
             params['nested'] = nested
+        if symbols is not None:
+            params['symbols'] = ",".join(symbols)
         url = '/orders'
         resp = self.get(url, params)
         if self._use_raw_data:


### PR DESCRIPTION
https://alpaca.markets/docs/api-documentation/api-v2/orders/#get-a-list-of-orders indicates you could use a list of symbols as filters. adding that as a param.

You could now run this code:

```py
api.list_orders(status="closed", symbols=["GOOG", "TSLA", "MSFT"])
```