### PR TITLE
Update rest.py

### DIFF
--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -560,7 +560,7 @@ class REST(object):
             data['page_token'] = page_token
             resp = self.data_get('/stocks/{}/{}'.format(symbol, endpoint),
                                  data=data, api_version='v2')
-            items = resp.get(endpoint, [])
+            items = resp.get(endpoint, []) or []
             for item in items:
                 yield item
             total_items += len(items)


### PR DESCRIPTION
Fix items assignment to handle the case where `endpoint` is `None`, closes #478