### PR TITLE
Read credentials from environment for async rest client

### DIFF
--- a/alpaca_trade_api/rest_async.py
+++ b/alpaca_trade_api/rest_async.py
@@ -4,7 +4,7 @@ import asyncio
 from alpaca_trade_api.entity_v2 import BarsV2, QuotesV2, TradesV2, \
     EntityList, TradeV2, QuoteV2
 import pandas as pd
-from alpaca_trade_api.common import URL, get_data_url
+from alpaca_trade_api.common import URL, get_credentials, get_data_url
 
 
 class AsyncRest:
@@ -19,7 +19,7 @@ class AsyncRest:
         :param raw_data: should we return api response raw or wrap it with
                          Entity objects.
         """
-        self._key_id, self._secret_key = key_id, secret_key
+        self._key_id, self._secret_key, _ = get_credentials(key_id, secret_key)
         self._data_url: URL = URL(data_url or get_data_url())
 
     def _get_historic_url(self, _type, symbol):


### PR DESCRIPTION
Closes #491

The async rest client currently doesn't use the `get_credentials` method for extracting credentials, meaning that it ignores 
environment variables. This PR rectifies the issue by ensuring that the async client also gets credentials in the same way
that the sync client does.
