### PR TITLE
get-bars changes limit behavior compared to get_barset

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ print(api.get_barset(['AAPL', 'GOOG'], 'minute', start=start, end=end).df)
 
 ```
 
-please note that if you are using limit, it is calculated from the start date. and if end date is not specified, "now" is used. <br>Take that under consideration when using end date with a limit. 
+(Deprecated: When using `get_barset()`, please note that if you are using limit, it is calculated from the end date. and if end date is not specified, "now" is used. Take that under consideration when using start date with a limit. ) <br>
+For `get_bars()`, when you are using limit, it is calculated from the start date.  If the end date is not specified, "now" is used. Take that under consideration when using end date with a limit.
 
 ---
 


### PR DESCRIPTION
The original README claims that limit is calculated from the end date.  This was true with get_barset, but for get_bars, limit is calculated from start instead.  I have corrected the README to reflect this.

For example, the following command will get 5 quotes starting from Oct 4, instead of the last 5 quotes ending Oct 20:

`api.get_bars("AAPL", TimeFrame.Day, start="2021-10-04", end="2022-10-20", limit=5, adjustment='raw')`