### PR TITLE
Chore/fix bar response

### DIFF
--- a/alpaca_trade_api/entity.py
+++ b/alpaca_trade_api/entity.py
@@ -16,8 +16,6 @@ class Entity(object):
         self._raw = raw
 
     def __getattr__(self, key):
-        print('RAW')
-        print(key)
         if key in self._raw:
             val = self._raw[key]
             if (isinstance(val, str) and

--- a/alpaca_trade_api/entity.py
+++ b/alpaca_trade_api/entity.py
@@ -16,6 +16,8 @@ class Entity(object):
         self._raw = raw
 
     def __getattr__(self, key):
+        print('RAW')
+        print(key)
         if key in self._raw:
             val = self._raw[key]
             if (isinstance(val, str) and

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -217,7 +217,13 @@ class REST(object):
             else:
                 raise
         if resp.text != '':
-            return resp.json()
+            result = resp.json()
+            try:
+                if result['bars'] == None:
+                    result['bars'] = []
+            except:
+                print('No bars on endpoint: {}'.format(url))
+            return result
         return None
 
     def get(self, path, data=None):


### PR DESCRIPTION
Full Disclosure:  I have never made an open-source PR before so please help me out if I'm missing anything.

While using the backtrade, I noticed that when making a request to the https://data.alpaca.markets/v2/stocks/<ticker>/bars endpoint, sometimes the `bars` value comes back as `None`.  There is some logic in the backtrader that attempts to iterate over these values and so an error is thrown saying `NoneType is not iterable`.  I am not sure if this is a backtrader issue or even an API issue but while that's being worked out, a path for the trade SDK seems necessary patch to resolve this issue.  