### PR TITLE
Update Python 3.7 CI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
       - run:
           name: run tests
           command: |
+            pip install pandas==1.3.4 numpy==1.21.4
             python setup.py install
             pip install flake8 && flake8 alpaca_trade_api tests
             python setup.py test


### PR DESCRIPTION
numpy 1.22.0+ only supports python 3.8+

This PR changes it so we override installation of numpy to version 1.21.4 and pandas to 1.3.4