### PR TITLE
empty handler check when unregister cancel errors + corrections

### DIFF
--- a/alpaca_trade_api/stream.py
+++ b/alpaca_trade_api/stream.py
@@ -422,7 +422,8 @@ class DataStream(_DataStream):
 
     def unregister_handler(self, msg_type, *symbols):
         for symbol in symbols:
-            del self._handlers[msg_type][symbol]
+            if symbol in self._handlers[msg_type]:
+                del self._handlers[msg_type][symbol]
 
 
 class CryptoDataStream(_DataStream):


### PR DESCRIPTION
## Context
Bug only exists for cancel errors and corrections because the `unregister_handler` method is called automatically when trades are unsubscribed.