### PR TITLE
Updated Stream Instructions for `sip` parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ async def quote_callback(q):
 # Initiate Class Instance
 stream = Stream(<ALPACA_API_KEY>,
                 <ALPACA_SECRET_KEY>,
-                base_url=URL('https://paper-api.alpaca.markets'),
+                base_url='https://paper-api.alpaca.markets',
                 data_feed='iex')  # <- replace to SIP if you have PRO subscription
 
 # subscribing to event
@@ -269,7 +269,7 @@ ie:
 # Initiate Class Instance
 stream = Stream(<ALPACA_API_KEY>,
                 <ALPACA_SECRET_KEY>,
-                base_url=URL('https://paper-api.alpaca.markets'),
+                base_url='https://paper-api.alpaca.markets',
                 data_feed='iex',
                 websocket_params =  {'ping_interval': 5}, #here we set ping_interval to 5 seconds 
                 )

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ async def quote_callback(q):
 # Initiate Class Instance
 stream = Stream(<ALPACA_API_KEY>,
                 <ALPACA_SECRET_KEY>,
-                base_url='https://paper-api.alpaca.markets',
+                base_url=URL('https://paper-api.alpaca.markets'),
                 data_feed='iex')  # <- replace to 'sip' if you have PRO subscription
 
 # subscribing to event
@@ -269,8 +269,8 @@ ie:
 # Initiate Class Instance
 stream = Stream(<ALPACA_API_KEY>,
                 <ALPACA_SECRET_KEY>,
-                base_url='https://paper-api.alpaca.markets',
-                data_feed='iex',
+                base_url=URL('https://paper-api.alpaca.markets'),
+                data_feed='iex', # <- replace to 'sip' if you have PRO subscription
                 websocket_params =  {'ping_interval': 5}, #here we set ping_interval to 5 seconds 
                 )
 ```

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ async def quote_callback(q):
 stream = Stream(<ALPACA_API_KEY>,
                 <ALPACA_SECRET_KEY>,
                 base_url='https://paper-api.alpaca.markets',
-                data_feed='iex')  # <- replace to SIP if you have PRO subscription
+                data_feed='iex')  # <- replace to 'sip' if you have PRO subscription
 
 # subscribing to event
 stream.subscribe_trades(trade_callback, 'AAPL')


### PR DESCRIPTION
I updated the Stream instructions to be more clear.
- They had an unneeded URL in the `README.md` updated it to reflect the proper way to call it.
- They had SIP parameter in all capitals in the instructions as well. Fixed this to reflect the proper way to call it.