### PR TITLE
crypto optionality for async module

### DIFF
--- a/alpaca_trade_api/__init__.py
+++ b/alpaca_trade_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 
 from .rest import REST, TimeFrame, TimeFrameUnit  # noqa
 from .rest_async import AsyncRest  # noqa

--- a/alpaca_trade_api/__init__.py
+++ b/alpaca_trade_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.3.0'
+__version__ = '2.2.0'
 
 from .rest import REST, TimeFrame, TimeFrameUnit  # noqa
 from .rest_async import AsyncRest  # noqa

--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -557,7 +557,6 @@ class REST(object):
                   resp_grouped_by_symbol: Optional[bool] = None,
                   page_limit: int = DATA_V2_MAX_LIMIT,
                   feed: Optional[str] = None,
-                  asof: Optional[str] = None,
                   **kwargs):
         page_token = None
         total_items = 0
@@ -578,8 +577,6 @@ class REST(object):
                 path += f'/{symbol_or_symbols}'
             else:
                 data['symbols'] = ','.join(symbol_or_symbols)
-            if asof:
-                data['asof'] = asof
             if endpoint:
                 path += f'/{endpoint}'
             resp = self.data_get(path, data=data, feed=feed,
@@ -600,21 +597,16 @@ class REST(object):
             if not page_token:
                 break
 
+
     def get_trades_iter(self,
                         symbol: Union[str, List[str]],
                         start: Optional[str] = None,
                         end: Optional[str] = None,
                         limit: int = None,
                         feed: Optional[str] = None,
-                        asof: Optional[str] = None,
                         raw=False) -> TradeIterator:
         trades = self._data_get('trades', symbol,
-                                start=start,
-                                end=end,
-                                limit=limit,
-                                feed=feed,
-                                asof=asof,
-                                )
+                                start=start, end=end, limit=limit, feed=feed)
         for trade in trades:
             if raw:
                 yield trade
@@ -627,15 +619,9 @@ class REST(object):
                    end: Optional[str] = None,
                    limit: int = None,
                    feed: Optional[str] = None,
-                   asof: Optional[str] = None,
                    ) -> TradesV2:
         trades = list(self.get_trades_iter(symbol,
-                                           start=start,
-                                           end=end,
-                                           limit=limit,
-                                           feed=feed,
-                                           asof=asof,
-                                           raw=True))
+                                           start, end, limit, feed, raw=True))
         return TradesV2(trades)
 
     def get_quotes_iter(self,
@@ -644,15 +630,9 @@ class REST(object):
                         end: Optional[str] = None,
                         limit: int = None,
                         feed: Optional[str] = None,
-                        asof: Optional[str] = None,
                         raw=False) -> QuoteIterator:
         quotes = self._data_get('quotes', symbol,
-                                start=start,
-                                end=end,
-                                limit=limit,
-                                feed=feed,
-                                asof=asof,
-                                )
+                                start=start, end=end, limit=limit, feed=feed)
         for quote in quotes:
             if raw:
                 yield quote
@@ -665,16 +645,13 @@ class REST(object):
                    end: Optional[str] = None,
                    limit: int = None,
                    feed: Optional[str] = None,
-                   asof: Optional[str] = None,
                    ) -> QuotesV2:
         quotes = list(self.get_quotes_iter(symbol=symbol,
                                            start=start,
                                            end=end,
                                            limit=limit,
                                            feed=feed,
-                                           raw=True,
-                                           asof=asof,
-                                           ))
+                                           raw=True))
         return QuotesV2(quotes)
 
     def get_bars_iter(self,
@@ -685,16 +662,11 @@ class REST(object):
                       adjustment: str = 'raw',
                       limit: int = None,
                       feed: Optional[str] = None,
-                      asof: Optional[str] = None,
                       raw=False) -> BarIterator:
         bars = self._data_get('bars', symbol,
                               timeframe=timeframe,
                               adjustment=adjustment,
-                              start=start,
-                              end=end,
-                              limit=limit,
-                              feed=feed,
-                              asof=asof)
+                              start=start, end=end, limit=limit, feed=feed)
         for bar in bars:
             if raw:
                 yield bar
@@ -709,7 +681,6 @@ class REST(object):
                  adjustment: str = 'raw',
                  limit: int = None,
                  feed: Optional[str] = None,
-                 asof: Optional[str] = None,
                  ) -> BarsV2:
         bars = list(self.get_bars_iter(symbol,
                                        timeframe,
@@ -718,7 +689,6 @@ class REST(object):
                                        adjustment,
                                        limit,
                                        feed=feed,
-                                       asof=asof,
                                        raw=True))
         return BarsV2(bars)
 

--- a/alpaca_trade_api/rest_async.py
+++ b/alpaca_trade_api/rest_async.py
@@ -71,6 +71,7 @@ class AsyncRest:
                              asset_type: str = 'stock',
                              limit=10000,
                              adjustment='raw',
+                             feed ='iex'
                             ):
         _type = "bars"
 
@@ -82,11 +83,15 @@ class AsyncRest:
             "end":        end,
             "timeframe":  timeframe,
             "limit":      limit,
+            "feed": feed
         }
 
         if asset_type == 'crypto':
             del payload['adjustment']
+            del payload['feed']
             payload['exchanges'] = 'FTXU'
+
+
 
         df = await self._iterate_requests(symbol, payload, limit, _type,
                                           BarsV2, asset_type)


### PR DESCRIPTION
the original async module only had the url and optionality for stocks.

I added some modifications (with the default option still being stocks) that one can provide 'crypto' as an asset class and that will shift the url and payload header when calling the API. 