### PR TITLE
Use a less restrictive requirement specification for `aiohttp`.

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,6 +5,6 @@ urllib3>1.24,<2
 websocket-client>=0.56.0,<2
 websockets>=9.0,<11
 msgpack==1.0.3
-aiohttp==3.8.1
+aiohttp~=3.8
 PyYAML==6.0
 deprecation==2.1.0


### PR DESCRIPTION
Fixes #671.

We should use a less restrictive requirement specification so that future `aiohttp` fixes are brought in automatically. `aiohttp~=3.8` will enable automatic upgrading to both new patch versions and new minor versions while disabling automatic upgrading to new major versions, which may have breaking API changes.