### PR TITLE
#573 close_all_positions should take optional cancel_orders argument

### DIFF
--- a/alpaca_trade_api/rest.py
+++ b/alpaca_trade_api/rest.py
@@ -524,9 +524,9 @@ class REST(object):
         resp = self.delete('/positions/{}'.format(symbol), data=data)
         return self.response_wrapper(resp, Position)
 
-    def close_all_positions(self) -> Positions:
+    def close_all_positions(self, cancel_orders: bool=False) -> Positions:
         """Liquidates all open positions at market price"""
-        resp = self.delete('/positions')
+        resp = self.delete('/positions', data={'cancel_orders': cancel_orders})
         if self._use_raw_data:
             return resp
         else:


### PR DESCRIPTION
Trying to resolve the issue #573: https://github.com/alpacahq/alpaca-trade-api-python/issues/573

The public API already has this option: https://docs.alpaca.markets/reference/deleteallopenpositions but it seems that it is missing in current implementation