### PR TITLE
fix: Use warnings.catch_warnings() instead of pytest.warns(None)

### DIFF
--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,3 +1,4 @@
+import warnings
 import alpaca_trade_api as tradeapi
 from alpaca_trade_api.rest import APIError
 
@@ -1173,5 +1174,6 @@ def test_errors(reqmock):
 
 def test_no_resource_warning_with_context_manager():
     with warnings.catch_warnings():  # ensure no warnings are raised
+        warnings.simplefilter("error")
         with tradeapi.REST("key-id", "secret-key", api_version="v1") as api:
             assert api

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1172,7 +1172,6 @@ def test_errors(reqmock):
 
 
 def test_no_resource_warning_with_context_manager():
-    with pytest.warns(None) as record:  # ensure no warnings are raised
-        with tradeapi.REST('key-id', 'secret-key', api_version='v1') as api:
+    with warnings.catch_warnings():  # ensure no warnings are raised
+        with tradeapi.REST("key-id", "secret-key", api_version="v1") as api:
             assert api
-    assert not record


### PR DESCRIPTION
- we have one unit test case failing in the below
- this PR resolves the test case

```

    def test_no_resource_warning_with_context_manager():
>       with pytest.warns(None) as record:  # ensure no warnings are raised

tests/test_rest.py:1175: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = WarningsChecker(record=True), expected_warning = None, match_expr = None

    def __init__(
        self,
        expected_warning: Optional[
            Union[Type[Warning], Tuple[Type[Warning], ...]]
        ] = Warning,
        match_expr: Optional[Union[str, Pattern[str]]] = None,
        *,
        _ispytest: bool = False,
    ) -> None:
        check_ispytest(_ispytest)
        super().__init__(_ispytest=True)
    
        msg = "exceptions must be derived from Warning, not %s"
        if expected_warning is None:
>           warnings.warn(WARNS_NONE_ARG, stacklevel=4)
E           pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
E           See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for alternatives in common use cases.

.eggs/pytest-8.0.0rc1-py3.10.egg/_pytest/recwarn.py:279: PytestRemovedIn8Warning
```

```
FAILED tests/test_rest.py::test_no_resource_warning_with_context_manager - pytest.PytestRemovedIn8Warning: Passing None has been deprecated.
See https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests for alternatives in common use cases.
```