### PR TITLE
Support Python 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,25 @@ jobs:
           command: |
             python setup.py test
 
+  build-test-python312:
+    docker:
+      - image: python:3.12
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: make sure install works
+          command: |
+            pip install .
+      - run:
+          name: view installed packages
+          command: |
+            pip freeze
+      - run:
+          name: unit test
+          command: |
+            python setup.py test
+
 workflows:
   version: 2
   build:
@@ -185,3 +204,4 @@ workflows:
       - build-python39
       - build-test-python310
       - build-test-python311
+      - build-test-python312

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         # you have to quote any version number ending in a 0 or gh truncates it. ie 3.10 turned into 3.1
-        python-version: [ 3.8, '3.10', 3.11 ]
+        python-version: [ 3.8, '3.10', 3.11, 3.12 ]
         os: [ ubuntu-latest ] #in the future we should add windows here
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![Updates](https://pyup.io/repos/github/alpacahq/alpaca-trade-api-python/shield.svg)](https://pyup.io/repos/github/alpacahq/alpaca-trade-api-python/)
 [![Python 3](https://pyup.io/repos/github/alpacahq/alpaca-trade-api-python/python-3-shield.svg)](https://pyup.io/repos/github/alpacahq/alpaca-trade-api-python/)
 
+# Deprecation Notice
+
+A new python SDK, [Alpaca-py](https://github.com/alpacahq/alpaca-py), is available. This SDK will be the primary python SDK starting in 2023. We recommend slowly moving over your code to use the new SDK. Keep in mind, we will be maintaining this repo as usual until the end of 2022.
+
 # alpaca-trade-api-python
 
 `alpaca-trade-api-python` is a python library for the [Alpaca Commission Free Trading API](https://alpaca.markets).
@@ -11,10 +15,6 @@ both REST and streaming data interfaces. For details of each API behavior,
 please see the online [API document](https://alpaca.markets/docs/api-documentation/api-v2/market-data/alpaca-data-api-v2/).
 
 Note that this package supports only python version 3.7 and above.
-
-## Deprecation Notice
-
-A new python SDK, [Alpaca-py](https://github.com/alpacahq/alpaca-py), is available. This SDK will be the primary python SDK starting in 2023. We recommend slowly moving over your code to use the new SDK. Keep in mind, we will be maintaining this repo as usual until the end of 2022.
 
 ## Install
 We support python>=3.7. If you want to work with python 3.6, please note that these package dropped support for python <3.7 for the following versions:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Deprecation Notice
 
-A new python SDK, [Alpaca-py](https://github.com/alpacahq/alpaca-py), is available. This SDK will be the primary python SDK starting in 2023. We recommend slowly moving over your code to use the new SDK. Keep in mind, we will be maintaining this repo as usual until the end of 2022.
+A new python SDK, [Alpaca-py](https://github.com/alpacahq/alpaca-py), is available. This SDK will be the primary python SDK starting in 2023. We recommend moving over your code to use the new SDK. Keep in mind, we will be maintaining this repo as usual until the end of 2022.
 
 # alpaca-trade-api-python
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,6 +5,6 @@ urllib3>1.24,<2
 websocket-client>=0.56.0,<2
 websockets>=9.0,<11
 msgpack==1.0.3
-aiohttp==3.8.3
+aiohttp>=3.8.3,<4
 PyYAML==6.0.1
 deprecation==2.1.0


### PR DESCRIPTION
- support python 3.12
- alpaca-trade-api-python is deprecated  and recommend to use [alpaca-py](https://github.com/alpacahq/alpaca-py)